### PR TITLE
Add diary entry date selection

### DIFF
--- a/frontend/src/components/diary/diary.module.css
+++ b/frontend/src/components/diary/diary.module.css
@@ -23,4 +23,18 @@
     display: flex;
     flex-grow: 1;
     justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+}
+
+.datePickerLabel {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 14px;
+}
+
+.datePicker {
+    font-size: 16px;
+    padding: 4px;
 }

--- a/frontend/src/components/diary/diary.tsx
+++ b/frontend/src/components/diary/diary.tsx
@@ -1,23 +1,38 @@
 import { FaPlus } from "react-icons/fa"
-import React from "react"
+import React, { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { postJson } from "../../api-methods"
 import { DiaryEntryList } from "./diary-entry-list"
 import styles from "./diary.module.css"
 
+const todayAsDateInputValue = () => new Date().toISOString().slice(0, 10)
+
 export const Diary = () => {
     const navigate = useNavigate()
+    const [newEntryDate, setNewEntryDate] = useState(todayAsDateInputValue())
 
     return (
         <div className={styles.container}>
             <div className={styles.header}>
                 <div className={styles.addButtonArea}>
+                    <label className={styles.datePickerLabel}>
+                        Entry date
+                        <input
+                            className={styles.datePicker}
+                            type="date"
+                            value={newEntryDate}
+                            onChange={e => setNewEntryDate(e.target.value)}
+                        />
+                    </label>
                     <FaPlus style={{
                         fontSize: "40px"
                     }} onClick={() => {
+                        const createdAt = newEntryDate ? `${newEntryDate}T12:00:00Z` : undefined
+
                         postJson<any>("/api/diary/entry", {
                             title: "New diary entry",
-                            body: ""
+                            body: "",
+                            createdAt
                         }).then(r => {
                             if (r.payload) {
                                 navigate("/diary/entry/" + r.payload.id)

--- a/routes/diary.go
+++ b/routes/diary.go
@@ -5,11 +5,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/j45k4/talktocow/models"
 	"github.com/aarondl/null/v8"
 	"github.com/aarondl/sqlboiler/v4/boil"
 	"github.com/aarondl/sqlboiler/v4/queries/qm"
+	"github.com/gin-gonic/gin"
+	"github.com/j45k4/talktocow/models"
 )
 
 type DiaryEntry struct {
@@ -21,8 +21,9 @@ type DiaryEntry struct {
 }
 
 type CreateDiaryEntryRequest struct {
-	Title string `json:"title"`
-	Body  string `json:"body"`
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
 }
 
 func CreateDiaryEntry(ctx *gin.Context) {
@@ -38,6 +39,21 @@ func CreateDiaryEntry(ctx *gin.Context) {
 		Title:           null.StringFrom(createRequest.Title),
 		Body:            null.StringFrom(createRequest.Body),
 		WhoPostedUserID: int(userSession.UserID),
+	}
+
+	if createRequest.CreatedAt != "" {
+		createdAt, err := time.Parse(time.RFC3339, createRequest.CreatedAt)
+
+		if err != nil {
+			createdAt, err = time.Parse("2006-01-02", createRequest.CreatedAt)
+		}
+
+		if err != nil {
+			ctx.JSON(400, CreateErrorResponse(InvalidInput, "Invalid diary entry date"))
+			return
+		}
+
+		entry.CreatedAt = createdAt
 	}
 
 	err := entry.Insert(ctx.Request.Context(), db, boil.Infer())


### PR DESCRIPTION
## Summary
- add a date picker when creating diary entries
- send the selected date to the diary entry API
- store a provided createdAt date on the backend and validate invalid dates

## Checks
- npm --prefix frontend run build
- gofmt -w routes/diary.go
- go test ./... *(fails: models test setup requires missing PostgreSQL CLI `dropdb`)*