### PR TITLE
Create diary entries after posting draft

### DIFF
--- a/frontend/src/components/diary/diary.module.css
+++ b/frontend/src/components/diary/diary.module.css
@@ -27,14 +27,48 @@
     gap: 12px;
 }
 
-.datePickerLabel {
+.newEntryButton {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 16px;
+    padding: 8px 12px;
+}
+
+.draftForm {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 20px;
+    padding: 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.draftField {
     display: flex;
     flex-direction: column;
     gap: 4px;
     font-size: 14px;
 }
 
+.draftField input,
+.draftField textarea {
+    font-size: 16px;
+    padding: 4px;
+}
+
+.draftField textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
 .datePicker {
     font-size: 16px;
     padding: 4px;
+}
+
+.draftActions {
+    display: flex;
+    gap: 8px;
 }

--- a/frontend/src/components/diary/diary.tsx
+++ b/frontend/src/components/diary/diary.tsx
@@ -10,12 +10,52 @@ const todayAsDateInputValue = () => new Date().toISOString().slice(0, 10)
 export const Diary = () => {
     const navigate = useNavigate()
     const [newEntryDate, setNewEntryDate] = useState(todayAsDateInputValue())
+    const [newEntryTitle, setNewEntryTitle] = useState("New diary entry")
+    const [newEntryBody, setNewEntryBody] = useState("")
+    const [isCreatingEntry, setIsCreatingEntry] = useState(false)
+    const [isPostingEntry, setIsPostingEntry] = useState(false)
+
+    const resetDraft = () => {
+        setNewEntryDate(todayAsDateInputValue())
+        setNewEntryTitle("New diary entry")
+        setNewEntryBody("")
+        setIsCreatingEntry(false)
+    }
+
+    const postEntry = () => {
+        const createdAt = newEntryDate ? `${newEntryDate}T12:00:00Z` : undefined
+
+        setIsPostingEntry(true)
+
+        postJson<any>("/api/diary/entry", {
+            title: newEntryTitle,
+            body: newEntryBody,
+            createdAt
+        }).then(r => {
+            if (r.payload) {
+                resetDraft()
+                navigate("/diary/entry/" + r.payload.id)
+            }
+        }).finally(() => {
+            setIsPostingEntry(false)
+        })
+    }
 
     return (
         <div className={styles.container}>
             <div className={styles.header}>
                 <div className={styles.addButtonArea}>
-                    <label className={styles.datePickerLabel}>
+                    <button className={styles.newEntryButton} onClick={() => {
+                        setIsCreatingEntry(true)
+                    }}>
+                        <FaPlus />
+                        New diary entry
+                    </button>
+                </div>
+            </div>
+            {isCreatingEntry && (
+                <div className={styles.draftForm}>
+                    <label className={styles.draftField}>
                         Entry date
                         <input
                             className={styles.datePicker}
@@ -24,24 +64,31 @@ export const Diary = () => {
                             onChange={e => setNewEntryDate(e.target.value)}
                         />
                     </label>
-                    <FaPlus style={{
-                        fontSize: "40px"
-                    }} onClick={() => {
-                        const createdAt = newEntryDate ? `${newEntryDate}T12:00:00Z` : undefined
-
-                        postJson<any>("/api/diary/entry", {
-                            title: "New diary entry",
-                            body: "",
-                            createdAt
-                        }).then(r => {
-                            if (r.payload) {
-                                navigate("/diary/entry/" + r.payload.id)
-                            }
-                        })
-                    }} />
+                    <label className={styles.draftField}>
+                        Title
+                        <input
+                            type="text"
+                            value={newEntryTitle}
+                            onChange={e => setNewEntryTitle(e.target.value)}
+                        />
+                    </label>
+                    <label className={styles.draftField}>
+                        Body
+                        <textarea
+                            value={newEntryBody}
+                            onChange={e => setNewEntryBody(e.target.value)}
+                        />
+                    </label>
+                    <div className={styles.draftActions}>
+                        <button onClick={postEntry} disabled={isPostingEntry}>
+                            {isPostingEntry ? "Posting..." : "Post"}
+                        </button>
+                        <button onClick={resetDraft} disabled={isPostingEntry}>
+                            Cancel
+                        </button>
+                    </div>
                 </div>
-                
-            </div>
+            )}
             <DiaryEntryList />
         </div>
     )


### PR DESCRIPTION
## Summary
- change the diary plus button to open a draft form instead of immediately creating an entry
- create the diary entry only when the user presses Post
- keep date selection, title, body, and Cancel in the draft flow

## Checks
- npm --prefix frontend run build
- git diff --check