### PR TITLE
Use reusable modal for diary draft

### DIFF
--- a/frontend/src/components/diary/diary.module.css
+++ b/frontend/src/components/diary/diary.module.css
@@ -39,10 +39,6 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
-    margin-bottom: 20px;
-    padding: 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
 }
 
 .draftField {

--- a/frontend/src/components/diary/diary.tsx
+++ b/frontend/src/components/diary/diary.tsx
@@ -2,6 +2,7 @@ import { FaPlus } from "react-icons/fa"
 import React, { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { postJson } from "../../api-methods"
+import { Modal } from "../modal"
 import { DiaryEntryList } from "./diary-entry-list"
 import styles from "./diary.module.css"
 
@@ -53,7 +54,7 @@ export const Diary = () => {
                     </button>
                 </div>
             </div>
-            {isCreatingEntry && (
+            <Modal isOpen={isCreatingEntry} title="New diary entry" onClose={resetDraft}>
                 <div className={styles.draftForm}>
                     <label className={styles.draftField}>
                         Entry date
@@ -88,7 +89,7 @@ export const Diary = () => {
                         </button>
                     </div>
                 </div>
-            )}
+            </Modal>
             <DiaryEntryList />
         </div>
     )

--- a/frontend/src/components/modal.module.css
+++ b/frontend/src/components/modal.module.css
@@ -1,0 +1,45 @@
+.backdrop {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 1000;
+}
+
+.modal {
+    width: min(100%, 560px);
+    max-height: calc(100vh - 32px);
+    overflow: auto;
+    background: white;
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid #ddd;
+}
+
+.title {
+    margin: 0;
+    font-size: 20px;
+}
+
+.closeButton {
+    border: none;
+    background: transparent;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.content {
+    padding: 16px;
+}

--- a/frontend/src/components/modal.tsx
+++ b/frontend/src/components/modal.tsx
@@ -1,0 +1,49 @@
+import React, { ReactNode, useEffect } from "react"
+import styles from "./modal.module.css"
+
+type ModalProps = {
+    isOpen: boolean
+    title: string
+    children: ReactNode
+    onClose: () => void
+}
+
+export const Modal = (props: ModalProps) => {
+    useEffect(() => {
+        if (!props.isOpen) {
+            return
+        }
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                props.onClose()
+            }
+        }
+
+        document.addEventListener("keydown", onKeyDown)
+
+        return () => {
+            document.removeEventListener("keydown", onKeyDown)
+        }
+    }, [props.isOpen, props.onClose])
+
+    if (!props.isOpen) {
+        return null
+    }
+
+    return (
+        <div className={styles.backdrop} onClick={props.onClose}>
+            <div className={styles.modal} role="dialog" aria-modal="true" aria-label={props.title} onClick={e => e.stopPropagation()}>
+                <div className={styles.header}>
+                    <h2 className={styles.title}>{props.title}</h2>
+                    <button className={styles.closeButton} type="button" aria-label="Close" onClick={props.onClose}>
+                        ×
+                    </button>
+                </div>
+                <div className={styles.content}>
+                    {props.children}
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- add a reusable Modal component with backdrop, header, close button, Escape, and outside-click close
- use the Modal for the new diary entry draft form
- keep entry creation deferred until Post is pressed

## Checks
- npm --prefix frontend run build
- git diff --check