### PR TITLE
Add mobile pull to refresh for diary

### DIFF
--- a/frontend/src/components/diary/diary-entry-list.tsx
+++ b/frontend/src/components/diary/diary-entry-list.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 
 import { DiaryEntry } from "./diary-entry"
 import { getJson } from "../../api-methods"
+import { PullToRefresh } from "../pull-to-refresh"
 
 import styles from "./diary-entry-list.module.css"
 
@@ -13,42 +14,51 @@ export const DiaryEntryList = () => {
 
     const [entries, setEntries] = useState<any[]>([])
 
-    useEffect(() => {
-        getJson<any>("/api/diary/entries?offset=" + offset).then(r => {
-            setEntries(r.payload)
-            setOffset(offset + r.payload.length)
-        })
+    const fetchFirstPage = useCallback(async () => {
+        const [entriesResponse, countResponse] = await Promise.all([
+            getJson<any>("/api/diary/entries?offset=0"),
+            getJson<any>("/api/diary/entries/count")
+        ])
 
-        getJson<any>("/api/diary/entries/count").then(r => {
-            setCount(r.payload.count)
-        })
+        const newEntries = entriesResponse.payload ?? []
+
+        setEntries(newEntries)
+        setOffset(newEntries.length)
+        setCount(countResponse.payload?.count ?? 0)
     }, [])
 
+    useEffect(() => {
+        fetchFirstPage()
+    }, [fetchFirstPage])
+
     return (
-        <div className={styles.container}>
-            <InfiniteScroll
-                dataLength={entries.length}
-                next={() => {
-                    console.log("Next")
+        <PullToRefresh onRefresh={fetchFirstPage}>
+            <div className={styles.container}>
+                <InfiniteScroll
+                    dataLength={entries.length}
+                    next={() => {
+                        console.log("Next")
 
-                    getJson<any>("/api/diary/entries?offset=" + offset).then(r => {
-                        setEntries([...entries, ...r.payload])
-                        setOffset(offset + r.payload.length)
-                    })
-                }}
-                hasMore={offset < count}
-                loader={<h4>loading</h4>}>
-                {entries.map(p => (
-                    <DiaryEntry
-                        key={p.id}
-                        id={p.id}
-                        title={p.title}
-                        body={p.body}
-                        postedAt={p.createdAt}
+                        getJson<any>("/api/diary/entries?offset=" + offset).then(r => {
+                            const newEntries = r.payload ?? []
+                            setEntries([...entries, ...newEntries])
+                            setOffset(offset + newEntries.length)
+                        })
+                    }}
+                    hasMore={offset < count}
+                    loader={<h4>loading</h4>}>
+                    {entries.map(p => (
+                        <DiaryEntry
+                            key={p.id}
+                            id={p.id}
+                            title={p.title}
+                            body={p.body}
+                            postedAt={p.createdAt}
 
-                    />
-                ))}
-            </InfiniteScroll>
-        </div>
+                        />
+                    ))}
+                </InfiniteScroll>
+            </div>
+        </PullToRefresh>
     )
 }

--- a/frontend/src/components/diary/diary-entry-list.tsx
+++ b/frontend/src/components/diary/diary-entry-list.tsx
@@ -32,7 +32,7 @@ export const DiaryEntryList = () => {
     }, [fetchFirstPage])
 
     return (
-        <PullToRefresh onRefresh={fetchFirstPage}>
+        <PullToRefresh onRefresh={() => window.location.reload()}>
             <div className={styles.container}>
                 <InfiniteScroll
                     dataLength={entries.length}

--- a/frontend/src/components/pull-to-refresh.module.css
+++ b/frontend/src/components/pull-to-refresh.module.css
@@ -1,0 +1,34 @@
+.container {
+    position: relative;
+    overscroll-behavior-y: contain;
+    touch-action: pan-x pan-y;
+}
+
+.indicator {
+    position: sticky;
+    top: 0;
+    display: flex;
+    justify-content: center;
+    height: 0;
+    overflow: visible;
+    pointer-events: none;
+    z-index: 10;
+}
+
+.indicatorContent {
+    margin-top: 8px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    color: #333;
+    font-size: 14px;
+    opacity: 0;
+    transform: translateY(-16px);
+    transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.visible {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/frontend/src/components/pull-to-refresh.tsx
+++ b/frontend/src/components/pull-to-refresh.tsx
@@ -1,0 +1,90 @@
+import React, { ReactNode, TouchEvent, useState } from "react"
+import styles from "./pull-to-refresh.module.css"
+
+type PullToRefreshProps = {
+    children: ReactNode
+    onRefresh: () => Promise<void> | void
+}
+
+const refreshThreshold = 80
+const maxPullDistance = 110
+
+export const PullToRefresh = (props: PullToRefreshProps) => {
+    const [startY, setStartY] = useState<number | null>(null)
+    const [pullDistance, setPullDistance] = useState(0)
+    const [isRefreshing, setIsRefreshing] = useState(false)
+
+    const canStartPull = () => window.scrollY <= 0 && !isRefreshing
+
+    const resetPull = () => {
+        setStartY(null)
+        setPullDistance(0)
+    }
+
+    const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+        if (!canStartPull()) {
+            return
+        }
+
+        setStartY(event.touches[0].clientY)
+    }
+
+    const onTouchMove = (event: TouchEvent<HTMLDivElement>) => {
+        if (startY === null || !canStartPull()) {
+            return
+        }
+
+        const distance = event.touches[0].clientY - startY
+
+        if (distance <= 0) {
+            setPullDistance(0)
+            return
+        }
+
+        setPullDistance(Math.min(distance, maxPullDistance))
+    }
+
+    const onTouchEnd = async () => {
+        if (startY === null) {
+            return
+        }
+
+        const shouldRefresh = pullDistance >= refreshThreshold
+
+        resetPull()
+
+        if (!shouldRefresh) {
+            return
+        }
+
+        setIsRefreshing(true)
+
+        try {
+            await props.onRefresh()
+        } finally {
+            setIsRefreshing(false)
+        }
+    }
+
+    const indicatorVisible = pullDistance > 10 || isRefreshing
+    const readyToRefresh = pullDistance >= refreshThreshold
+
+    return (
+        <div
+            className={styles.container}
+            onTouchStart={onTouchStart}
+            onTouchMove={onTouchMove}
+            onTouchEnd={onTouchEnd}
+            onTouchCancel={resetPull}
+        >
+            <div className={styles.indicator}>
+                <div className={`${styles.indicatorContent} ${indicatorVisible ? styles.visible : ""}`}>
+                    {isRefreshing ? "Refreshing..." : readyToRefresh ? "Release to refresh" : "Pull to refresh"}
+                </div>
+            </div>
+            <div style={{ transform: pullDistance ? `translateY(${pullDistance / 2}px)` : undefined }}>
+                {props.children}
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- add a reusable PullToRefresh component for touch devices
- show pull/release/refreshing feedback while swiping down
- wire pull-to-refresh into the diary entry list to reload the first page and count

## Checks
- npm --prefix frontend run build
- git diff --check