### PR TITLE
Add backend e2e test harness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD go.sum go.sum
 RUN go mod download
 
 ADD main.go main.go
+ADD app.go app.go
 COPY auth auth
 COPY config config
 COPY models models

--- a/app.go
+++ b/app.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/j45k4/talktocow/chatroom"
+	"github.com/j45k4/talktocow/config"
+	"github.com/j45k4/talktocow/eventbus"
+	"github.com/j45k4/talktocow/routes"
+)
+
+func corsOriginAllowed(origin string) bool {
+	for _, allowedOrigin := range config.CORSAllowOrigins {
+		if origin == allowedOrigin {
+			return true
+		}
+	}
+
+	parsedOrigin, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	hostname := parsedOrigin.Hostname()
+	if hostname == "localhost" || hostname == "puppe" || strings.HasSuffix(hostname, ".local") {
+		return true
+	}
+
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		return false
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate()
+}
+
+func registerFrontendRoutes(r *gin.Engine, distPath string) {
+	if distPath == "" {
+		return
+	}
+
+	indexPath := filepath.Join(distPath, "index.html")
+	if _, err := os.Stat(indexPath); err != nil {
+		log.Printf("frontend dist not available at %s", distPath)
+		return
+	}
+
+	r.NoRoute(func(ctx *gin.Context) {
+		if ctx.Request.URL.Path == "/api" || strings.HasPrefix(ctx.Request.URL.Path, "/api/") {
+			ctx.JSON(http.StatusNotFound, routes.CreateErrorResponse(routes.NotFound, "Not found"))
+			return
+		}
+
+		requestPath := path.Clean("/" + ctx.Request.URL.Path)
+		filePath := filepath.Join(distPath, filepath.FromSlash(strings.TrimPrefix(requestPath, "/")))
+		relativePath, err := filepath.Rel(distPath, filePath)
+		if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
+			ctx.JSON(http.StatusNotFound, routes.CreateErrorResponse(routes.NotFound, "Not found"))
+			return
+		}
+
+		fileInfo, err := os.Stat(filePath)
+		if err == nil && !fileInfo.IsDir() {
+			ctx.File(filePath)
+			return
+		}
+
+		ctx.File(indexPath)
+	})
+}
+
+func setupRouter(db *sql.DB, eventbus *eventbus.Eventbus, chatroomEventbus *chatroom.ChatroomEventbus) *gin.Engine {
+	r := gin.Default()
+
+	corsConfig := cors.DefaultConfig()
+	corsConfig.AllowCredentials = true
+	corsConfig.AllowOrigins = []string{}
+	corsConfig.AllowOriginFunc = corsOriginAllowed
+	corsConfig.AddAllowMethods("OPTIONS")
+	corsConfig.AddAllowHeaders("authorization")
+	corsConfig.AddAllowHeaders("x-device-id")
+	r.Use(cors.New(corsConfig))
+
+	r.Use(func(ctx *gin.Context) {
+		ctx.Set("db", db)
+		ctx.Set("eventbus", eventbus)
+		chatroom.SetChatroomEventbus(ctx, chatroomEventbus)
+	})
+
+	r.POST("/api/login", routes.HandleLogin)
+	r.POST("/api/token", routes.HandleTokenLogin)
+	r.POST("/api/passkeys/login/begin", routes.HandlePasskeyLoginBegin)
+	r.POST("/api/passkeys/login/finish", routes.HandlePasskeyLoginFinish)
+	r.POST("/api/logout", routes.HandleLogout)
+	r.GET("/api/ws", routes.HandleWs)
+
+	authenticated := r.Group("", routes.SessionMiddleware)
+
+	authenticated.GET("/api/passkeys", routes.GetPasskeys)
+	authenticated.POST("/api/passkeys/registration/begin", routes.HandlePasskeyRegistrationBegin)
+	authenticated.POST("/api/passkeys/registration/finish", routes.HandlePasskeyRegistrationFinish)
+	authenticated.GET("/api/users", routes.GetUsers)
+	authenticated.GET("/api/chatrooms", routes.GetChatrooms)
+	authenticated.POST("/api/chatroom", routes.CreateChatroom)
+	authenticated.GET("/api/chatroom/:chatroomId", routes.GetChatroom)
+	authenticated.PATCH("/api/chatroom/:chatroomId", routes.PatchChatroom)
+	authenticated.POST("/api/chatroom/:chatroomId/member", routes.AddChatroomMember)
+	authenticated.DELETE("/api/chatroom/:chatroomId/member/:userId", routes.RemoveChatroomMember)
+	authenticated.GET("/api/chatroom/:chatroomId/members", routes.GetChatroomMembers)
+	authenticated.GET("/api/chatroom/:chatroomId/messages", routes.GetChatroomMessages)
+	authenticated.GET("/api/mychatrooms", routes.GetMyChatrooms)
+	authenticated.GET("/api/messages", routes.HandleGetMessages)
+	authenticated.GET("/api/socket", routes.HandleSocket)
+	authenticated.POST("/api/files", routes.UploadFile)
+	authenticated.GET("/api/files/:fileId", routes.GetFile)
+	authenticated.DELETE("/api/files/:fileId", routes.DeleteFile)
+	authenticated.POST("/api/diary/entry", routes.CreateDiaryEntry)
+	authenticated.GET("/api/diary/entries", routes.GetDiaryEntries)
+	authenticated.GET("/api/diary/entries/count", routes.GetDiaryEntriesCount)
+	authenticated.GET("/api/diary/labels", routes.GetDiaryLabels)
+	authenticated.GET("/api/diary/entry/:diaryEntryId", routes.GetDiaryEntry)
+	authenticated.PUT("/api/diary/entry/:diaryEntryId", routes.UpdateDiaryEntry)
+	authenticated.DELETE("/api/diary/entry/:diaryEntryId", routes.DeleteDiaryEntry)
+	authenticated.GET("/api/diary/entry/:diaryEntryId/pictures", routes.GetDiaryEntryPictures)
+	authenticated.POST("/api/diary/entry/:diaryEntryId/picture", routes.UploadDiaryEntryPicture)
+	authenticated.GET("/api/diary/entry/:diaryEntryId/picture/:pictureId", routes.GetDiaryEntryPicture)
+	authenticated.DELETE("/api/diary/entry/:diaryEntryId/picture/:pictureId", routes.DeleteDiaryEntryPicture)
+
+	authenticated.POST("/api/diary/entry/:diaryEntryId/comment", routes.CreateDiaryEntryComment)
+	authenticated.POST("/api/diary/entry/:diaryEntryId/comment/:commentId", routes.UpdateDiaryEntryComment)
+	authenticated.DELETE("/api/diary/entry/:diaryEntryId/comment/:commentId", routes.DeleteDiaryEntryComment)
+	authenticated.GET("/api/diary/entry/:diaryEntryId/comments", routes.GetDiaryEntryComments)
+	authenticated.GET("/api/diary/entry/:diaryEntryId/comments/count", routes.GetDiaryEntryCommentsCount)
+
+	authenticated.POST("/api/pushovertoken", routes.CreatePushoverToken)
+	authenticated.GET("/api/pushovertokens", routes.GetPushoverTokens)
+	authenticated.DELETE("/api/pushovertoken/:pushoverTokenId", routes.DeletePushoverToken)
+	authenticated.GET("/api/pushovertoken/:pushoverTokenId", routes.GetPushoverToken)
+
+	authenticated.GET("/api/course/:courseId", routes.GetCourse)
+	authenticated.GET("/api/courses", routes.GetCourses)
+	authenticated.POST("/api/course", routes.CreateCourse)
+	authenticated.PUT("/api/course/:courseId", routes.UpdateCourse)
+	authenticated.GET("/api/course/:courseId/mymeta", routes.GetCourseMeta)
+
+	authenticated.GET("/api/course/:courseId/homeworks", routes.GetHomeworks)
+	authenticated.POST("/api/course/:courseId/homework", routes.CreateHomework)
+	authenticated.PUT("/api/course/:courseId/homework/:homeworkId", routes.UpdateHomework)
+	authenticated.GET("/api/course/:courseId/homework/:homeworkId", routes.GetHomework)
+	authenticated.POST("/api/course/:courseId/homework/:homeworkId/submit", routes.SubmitHomework)
+
+	authenticated.POST("/api/course/:courseId/homework/:homeworkId/submission", routes.SubmitHomework)
+	authenticated.GET("/api/course/:courseId/homework/:homeworkId/submissions", routes.GetHomeworkSubmissions)
+	authenticated.GET("/api/course/:courseId/student/:userId/submissions", routes.GetStudentSubmissions)
+	authenticated.GET("/api/course/:courseId/students", routes.GetCourseStudents)
+	authenticated.POST("/api/course/:courseId/student", routes.AddUserToCourse)
+
+	return r
+}

--- a/backend_e2e_test.go
+++ b/backend_e2e_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/j45k4/talktocow/auth"
+	"github.com/j45k4/talktocow/chatroom"
+	"github.com/j45k4/talktocow/config"
+	"github.com/j45k4/talktocow/eventbus"
+	_ "github.com/lib/pq"
+	migrate "github.com/rubenv/sql-migrate"
+)
+
+type e2eHarness struct {
+	t      *testing.T
+	db     *sql.DB
+	server http.Handler
+	userID int
+}
+
+func TestBackendE2EAuthFilesAndDiary(t *testing.T) {
+	if os.Getenv("TALKTOCOW_E2E") != "1" {
+		t.Skip("set TALKTOCOW_E2E=1 to run backend e2e tests against the configured Postgres database")
+	}
+
+	h := newE2EHarness(t)
+	defer h.cleanup()
+
+	username := fmt.Sprintf("e2e_%d", time.Now().UnixNano())
+	password := "test-password"
+	h.createUser(username, password)
+
+	tokenLogin := h.jsonRequest("POST", "/api/token", map[string]string{
+		"username": username,
+		"password": password,
+	}, nil)
+	assertStatus(t, tokenLogin, http.StatusOK)
+
+	var tokenBody struct {
+		Token    string `json:"token"`
+		UserID   string `json:"userId"`
+		Username string `json:"username"`
+	}
+	decodeJSON(t, tokenLogin.Body, &tokenBody)
+	if tokenBody.Token == "" {
+		t.Fatalf("/api/token did not return a token: %#v", tokenBody)
+	}
+	if tokenBody.Username != username {
+		t.Fatalf("/api/token returned username %q, want %q", tokenBody.Username, username)
+	}
+
+	fileID := h.uploadJPEGWithBearer(tokenBody.Token)
+	medium := h.request("GET", fmt.Sprintf("/api/files/%d?size=medium", fileID), nil, map[string]string{
+		"Authorization": "Bearer " + tokenBody.Token,
+	})
+	assertStatus(t, medium, http.StatusOK)
+	if contentType := medium.Header().Get("Content-Type"); contentType != "image/jpeg" {
+		t.Fatalf("medium content type = %q, want image/jpeg", contentType)
+	}
+
+	img, err := jpeg.Decode(medium.Body)
+	if err != nil {
+		t.Fatalf("decode medium jpeg: %v", err)
+	}
+	if got, want := img.Bounds().Dx(), 960; got != want {
+		t.Fatalf("medium width = %d, want %d", got, want)
+	}
+	if got, want := img.Bounds().Dy(), 1280; got != want {
+		t.Fatalf("medium height = %d, want %d", got, want)
+	}
+
+	cookieLogin := h.jsonRequest("POST", "/api/login", map[string]string{
+		"username": username,
+		"password": password,
+	}, nil)
+	assertStatus(t, cookieLogin, http.StatusOK)
+	if token := jsonField(t, cookieLogin.Body.Bytes(), "token"); token != "" {
+		t.Fatalf("/api/login returned token %q; browser login should rely on HttpOnly cookie", token)
+	}
+
+	cookies := cookieLogin.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("/api/login did not set an auth cookie")
+	}
+
+	diary := h.jsonRequest("POST", "/api/diary/entry", map[string]any{
+		"title":          "E2E diary entry",
+		"body":           "Uploaded through backend e2e test",
+		"createdAt":      "2026-05-11T12:00:00Z",
+		"pictureFileIds": []int{fileID},
+	}, cookies)
+	assertStatus(t, diary, http.StatusOK)
+	if id := jsonField(t, diary.Body.Bytes(), "id"); id == "" {
+		t.Fatalf("diary create response did not include id: %s", diary.Body.String())
+	}
+}
+
+func newE2EHarness(t *testing.T) *e2eHarness {
+	t.Helper()
+
+	oldFileStoragePath := config.FileStoragePath
+	config.FileStoragePath = t.TempDir()
+	t.Cleanup(func() {
+		config.FileStoragePath = oldFileStoragePath
+	})
+
+	connectionString := fmt.Sprintf("dbname=%s user=%s password=%s host=%s port=%s sslmode=disable", config.DBName, config.DBUser, config.DBPassword, config.DbHost, config.DBPort)
+	db, err := sql.Open("postgres", connectionString)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	migrations := &migrate.FileMigrationSource{Dir: "./migrations"}
+	if _, err := migrate.Exec(db, "postgres", migrations, migrate.Up); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	return &e2eHarness{
+		t:      t,
+		db:     db,
+		server: setupRouter(db, eventbus.New(), chatroom.NewChatroomEventbus()),
+	}
+}
+
+func (h *e2eHarness) createUser(username, password string) {
+	h.t.Helper()
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		h.t.Fatalf("hash password: %v", err)
+	}
+
+	err = h.db.QueryRowContext(context.Background(), `
+		insert into users (name, username, password_hash, created_at)
+		values ($1, $1, $2, now())
+		returning id
+	`, username, hash).Scan(&h.userID)
+	if err != nil {
+		h.t.Fatalf("insert e2e user: %v", err)
+	}
+}
+
+func (h *e2eHarness) cleanup() {
+	if h.userID == 0 {
+		return
+	}
+
+	ctx := context.Background()
+	_, _ = h.db.ExecContext(ctx, `delete from diary_entry_comments where user_id = $1`, h.userID)
+	_, _ = h.db.ExecContext(ctx, `delete from diary_entry_pictures where diary_entry_id in (select id from diary_entries where user_id = $1)`, h.userID)
+	_, _ = h.db.ExecContext(ctx, `delete from shared_diary_entries where diary_entry_id in (select id from diary_entries where user_id = $1)`, h.userID)
+	_, _ = h.db.ExecContext(ctx, `delete from diary_entries where user_id = $1`, h.userID)
+	_, _ = h.db.ExecContext(ctx, `delete from files where uploaded_by_user_id = $1`, h.userID)
+	_, _ = h.db.ExecContext(ctx, `delete from users where id = $1`, h.userID)
+}
+
+func (h *e2eHarness) jsonRequest(method, path string, body any, cookies []*http.Cookie) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		h.t.Fatalf("marshal request: %v", err)
+	}
+
+	return h.request(method, path, bytes.NewReader(payload), map[string]string{
+		"Content-Type": "application/json",
+	}, cookies...)
+}
+
+func (h *e2eHarness) request(method, path string, body io.Reader, headers map[string]string, cookies ...*http.Cookie) *httptest.ResponseRecorder {
+	h.t.Helper()
+
+	req := httptest.NewRequest(method, path, body)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	w := httptest.NewRecorder()
+	h.server.ServeHTTP(w, req)
+	return w
+}
+
+func (h *e2eHarness) uploadJPEGWithBearer(token string) int {
+	h.t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "oriented.jpg")
+	if err != nil {
+		h.t.Fatalf("create multipart file: %v", err)
+	}
+	if _, err := part.Write(orientedJPEGFixture(h.t)); err != nil {
+		h.t.Fatalf("write multipart file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		h.t.Fatalf("close multipart writer: %v", err)
+	}
+
+	response := h.request("POST", "/api/files", &body, map[string]string{
+		"Authorization": "Bearer " + token,
+		"Content-Type":  writer.FormDataContentType(),
+	})
+	assertStatus(h.t, response, http.StatusOK)
+
+	fileID, err := strconv.Atoi(jsonField(h.t, response.Body.Bytes(), "id"))
+	if err != nil {
+		h.t.Fatalf("parse uploaded file id: %v; body=%s", err, response.Body.String())
+	}
+	return fileID
+}
+
+func orientedJPEGFixture(t *testing.T) []byte {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 1600, 1200))
+	for y := 0; y < 1200; y++ {
+		for x := 0; x < 1600; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 180, A: 255})
+		}
+	}
+
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, img, &jpeg.Options{Quality: 90}); err != nil {
+		t.Fatalf("encode fixture jpeg: %v", err)
+	}
+
+	return injectEXIFOrientation(t, encoded.Bytes(), 6)
+}
+
+func injectEXIFOrientation(t *testing.T, jpegData []byte, orientation uint16) []byte {
+	t.Helper()
+
+	if len(jpegData) < 2 || jpegData[0] != 0xff || jpegData[1] != 0xd8 {
+		t.Fatalf("fixture is not a jpeg")
+	}
+
+	var tiff bytes.Buffer
+	tiff.WriteString("MM")
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(42))
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(8))
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(1))
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(0x0112))
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(3))
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(1))
+	_ = binary.Write(&tiff, binary.BigEndian, orientation)
+	_ = binary.Write(&tiff, binary.BigEndian, uint16(0))
+	_ = binary.Write(&tiff, binary.BigEndian, uint32(0))
+
+	exifPayload := append([]byte("Exif\x00\x00"), tiff.Bytes()...)
+	segmentLength := len(exifPayload) + 2
+	if segmentLength > 0xffff {
+		t.Fatalf("exif segment too large")
+	}
+
+	var out bytes.Buffer
+	out.Write(jpegData[:2])
+	out.Write([]byte{0xff, 0xe1, byte(segmentLength >> 8), byte(segmentLength)})
+	out.Write(exifPayload)
+	out.Write(jpegData[2:])
+	return out.Bytes()
+}
+
+func assertStatus(t *testing.T, response *httptest.ResponseRecorder, want int) {
+	t.Helper()
+	if response.Code != want {
+		t.Fatalf("status = %d, want %d; body=%s", response.Code, want, response.Body.String())
+	}
+}
+
+func decodeJSON(t *testing.T, body *bytes.Buffer, target any) {
+	t.Helper()
+	if err := json.Unmarshal(body.Bytes(), target); err != nil {
+		t.Fatalf("decode json %q: %v", body.String(), err)
+	}
+}
+
+func jsonField(t *testing.T, data []byte, field string) string {
+	t.Helper()
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode json %q: %v", string(data), err)
+	}
+
+	value, ok := payload[field]
+	if !ok || value == nil {
+		return ""
+	}
+
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case float64:
+		return strconv.Itoa(int(typed))
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("TALKTOCOW_E2E") == "1" {
+		if cwd, err := os.Getwd(); err == nil {
+			_ = os.Setenv("PATH", filepath.Join(cwd, "node_modules", ".bin")+string(os.PathListSeparator)+os.Getenv("PATH"))
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/main.go
+++ b/main.go
@@ -7,86 +7,16 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"net"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 
-	"github.com/gin-contrib/cors"
-	"github.com/gin-gonic/gin"
 	"github.com/j45k4/talktocow/bot"
 	"github.com/j45k4/talktocow/chatroom"
 	"github.com/j45k4/talktocow/config"
 	"github.com/j45k4/talktocow/eventbus"
-	"github.com/j45k4/talktocow/routes"
 	_ "github.com/lib/pq"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	migrate "github.com/rubenv/sql-migrate"
 )
-
-func corsOriginAllowed(origin string) bool {
-	for _, allowedOrigin := range config.CORSAllowOrigins {
-		if origin == allowedOrigin {
-			return true
-		}
-	}
-
-	parsedOrigin, err := url.Parse(origin)
-	if err != nil {
-		return false
-	}
-
-	hostname := parsedOrigin.Hostname()
-	if hostname == "localhost" || hostname == "puppe" || strings.HasSuffix(hostname, ".local") {
-		return true
-	}
-
-	ip := net.ParseIP(hostname)
-	if ip == nil {
-		return false
-	}
-
-	return ip.IsLoopback() || ip.IsPrivate()
-}
-
-func registerFrontendRoutes(r *gin.Engine, distPath string) {
-	if distPath == "" {
-		return
-	}
-
-	indexPath := filepath.Join(distPath, "index.html")
-	if _, err := os.Stat(indexPath); err != nil {
-		log.Printf("frontend dist not available at %s", distPath)
-		return
-	}
-
-	r.NoRoute(func(ctx *gin.Context) {
-		if ctx.Request.URL.Path == "/api" || strings.HasPrefix(ctx.Request.URL.Path, "/api/") {
-			ctx.JSON(http.StatusNotFound, routes.CreateErrorResponse(routes.NotFound, "Not found"))
-			return
-		}
-
-		requestPath := path.Clean("/" + ctx.Request.URL.Path)
-		filePath := filepath.Join(distPath, filepath.FromSlash(strings.TrimPrefix(requestPath, "/")))
-		relativePath, err := filepath.Rel(distPath, filePath)
-		if err != nil || relativePath == ".." || strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) {
-			ctx.JSON(http.StatusNotFound, routes.CreateErrorResponse(routes.NotFound, "Not found"))
-			return
-		}
-
-		fileInfo, err := os.Stat(filePath)
-		if err == nil && !fileInfo.IsDir() {
-			ctx.File(filePath)
-			return
-		}
-
-		ctx.File(indexPath)
-	})
-}
 
 func main() {
 	log.Printf("Private key path %v", config.PrivateKeyPath)
@@ -97,10 +27,8 @@ func main() {
 	log.Printf("connection string %v", connectionString)
 
 	db, err := sql.Open("postgres", connectionString)
-
 	if err != nil {
 		log.Printf("opening database connection failed %v", err)
-
 		return
 	}
 
@@ -109,17 +37,14 @@ func main() {
 	}
 
 	_, err = migrate.Exec(db, "postgres", migrations, migrate.Up)
-
 	if err != nil {
 		log.Printf("failed to execute migrations %v", err)
-
 		panic("Failed to execute migrations")
 	}
 
 	bot.InitializeBots(db)
 
 	eventbus := eventbus.New()
-
 	cowgpt := bot.CowGPT{
 		Eventbus:   eventbus,
 		Client:     openai.NewClient(option.WithAPIKey(config.OpenAIApiKey)),
@@ -127,98 +52,11 @@ func main() {
 		Ctx:        context.Background(),
 		DB:         db,
 	}
-
 	go cowgpt.Run()
 
 	chatroomEventbus := chatroom.NewChatroomEventbus()
-
-	r := gin.Default()
-
-	corsConfig := cors.DefaultConfig()
-
-	corsConfig.AllowCredentials = true
-	corsConfig.AllowOrigins = []string{}
-	corsConfig.AllowOriginFunc = corsOriginAllowed
-	corsConfig.AddAllowMethods("OPTIONS")
-	corsConfig.AddAllowHeaders("authorization")
-	corsConfig.AddAllowHeaders("x-device-id")
-	r.Use(cors.New(corsConfig))
-
-	r.Use(func(ctx *gin.Context) {
-		ctx.Set("db", db)
-		ctx.Set("eventbus", eventbus)
-		chatroom.SetChatroomEventbus(ctx, chatroomEventbus)
-	})
-
-	r.POST("/api/login", routes.HandleLogin)
-	r.POST("/api/token", routes.HandleTokenLogin)
-	r.POST("/api/passkeys/login/begin", routes.HandlePasskeyLoginBegin)
-	r.POST("/api/passkeys/login/finish", routes.HandlePasskeyLoginFinish)
-	r.POST("/api/logout", routes.HandleLogout)
-	r.GET("/api/ws", routes.HandleWs)
-
+	r := setupRouter(db, eventbus, chatroomEventbus)
 	registerFrontendRoutes(r, config.FrontendDistPath)
-
-	authenticated := r.Group("", routes.SessionMiddleware)
-
-	authenticated.GET("/api/passkeys", routes.GetPasskeys)
-	authenticated.POST("/api/passkeys/registration/begin", routes.HandlePasskeyRegistrationBegin)
-	authenticated.POST("/api/passkeys/registration/finish", routes.HandlePasskeyRegistrationFinish)
-	authenticated.GET("/api/users", routes.GetUsers)
-	authenticated.GET("/api/chatrooms", routes.GetChatrooms)
-	authenticated.POST("/api/chatroom", routes.CreateChatroom)
-	authenticated.GET("/api/chatroom/:chatroomId", routes.GetChatroom)
-	authenticated.PATCH("/api/chatroom/:chatroomId", routes.PatchChatroom)
-	authenticated.POST("/api/chatroom/:chatroomId/member", routes.AddChatroomMember)
-	authenticated.DELETE("/api/chatroom/:chatroomId/member/:userId", routes.RemoveChatroomMember)
-	authenticated.GET("/api/chatroom/:chatroomId/members", routes.GetChatroomMembers)
-	authenticated.GET("/api/chatroom/:chatroomId/messages", routes.GetChatroomMessages)
-	authenticated.GET("/api/mychatrooms", routes.GetMyChatrooms)
-	authenticated.GET("/api/messages", routes.HandleGetMessages)
-	authenticated.GET("/api/socket", routes.HandleSocket)
-	authenticated.POST("/api/files", routes.UploadFile)
-	authenticated.GET("/api/files/:fileId", routes.GetFile)
-	authenticated.DELETE("/api/files/:fileId", routes.DeleteFile)
-	authenticated.POST("/api/diary/entry", routes.CreateDiaryEntry)
-	authenticated.GET("/api/diary/entries", routes.GetDiaryEntries)
-	authenticated.GET("/api/diary/entries/count", routes.GetDiaryEntriesCount)
-	authenticated.GET("/api/diary/labels", routes.GetDiaryLabels)
-	authenticated.GET("/api/diary/entry/:diaryEntryId", routes.GetDiaryEntry)
-	authenticated.PUT("/api/diary/entry/:diaryEntryId", routes.UpdateDiaryEntry)
-	authenticated.DELETE("/api/diary/entry/:diaryEntryId", routes.DeleteDiaryEntry)
-	authenticated.GET("/api/diary/entry/:diaryEntryId/pictures", routes.GetDiaryEntryPictures)
-	authenticated.POST("/api/diary/entry/:diaryEntryId/picture", routes.UploadDiaryEntryPicture)
-	authenticated.GET("/api/diary/entry/:diaryEntryId/picture/:pictureId", routes.GetDiaryEntryPicture)
-	authenticated.DELETE("/api/diary/entry/:diaryEntryId/picture/:pictureId", routes.DeleteDiaryEntryPicture)
-
-	authenticated.POST("/api/diary/entry/:diaryEntryId/comment", routes.CreateDiaryEntryComment)
-	authenticated.POST("/api/diary/entry/:diaryEntryId/comment/:commentId", routes.UpdateDiaryEntryComment)
-	authenticated.DELETE("/api/diary/entry/:diaryEntryId/comment/:commentId", routes.DeleteDiaryEntryComment)
-	authenticated.GET("/api/diary/entry/:diaryEntryId/comments", routes.GetDiaryEntryComments)
-	authenticated.GET("/api/diary/entry/:diaryEntryId/comments/count", routes.GetDiaryEntryCommentsCount)
-
-	authenticated.POST("/api/pushovertoken", routes.CreatePushoverToken)
-	authenticated.GET("/api/pushovertokens", routes.GetPushoverTokens)
-	authenticated.DELETE("/api/pushovertoken/:pushoverTokenId", routes.DeletePushoverToken)
-	authenticated.GET("/api/pushovertoken/:pushoverTokenId", routes.GetPushoverToken)
-
-	authenticated.GET("/api/course/:courseId", routes.GetCourse)
-	authenticated.GET("/api/courses", routes.GetCourses)
-	authenticated.POST("/api/course", routes.CreateCourse)
-	authenticated.PUT("/api/course/:courseId", routes.UpdateCourse)
-	authenticated.GET("/api/course/:courseId/mymeta", routes.GetCourseMeta)
-
-	authenticated.GET("/api/course/:courseId/homeworks", routes.GetHomeworks)
-	authenticated.POST("/api/course/:courseId/homework", routes.CreateHomework)
-	authenticated.PUT("/api/course/:courseId/homework/:homeworkId", routes.UpdateHomework)
-	authenticated.GET("/api/course/:courseId/homework/:homeworkId", routes.GetHomework)
-	authenticated.POST("/api/course/:courseId/homework/:homeworkId/submit", routes.SubmitHomework)
-
-	authenticated.POST("/api/course/:courseId/homework/:homeworkId/submission", routes.SubmitHomework)
-	authenticated.GET("/api/course/:courseId/homework/:homeworkId/submissions", routes.GetHomeworkSubmissions)
-	authenticated.GET("/api/course/:courseId/student/:userId/submissions", routes.GetStudentSubmissions)
-	authenticated.GET("/api/course/:courseId/students", routes.GetCourseStudents)
-	authenticated.POST("/api/course/:courseId/student", routes.AddUserToCourse)
 
 	r.Run(":12001")
 }

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,11 @@ Start database with docker compose
 ```
 docker compose up
 ```
+## Backend e2e tests
+
+The backend e2e suite boots the Gin router in-process and drives real HTTP requests against the configured Postgres database.
+It is opt-in because it creates temporary users/files/diary entries in the configured DB.
+
+```
+TALKTOCOW_E2E=1 go test . -run TestBackendE2E
+```


### PR DESCRIPTION
## Summary
- rebase the backend e2e harness onto current `master`
- extract router setup into `app.go` so tests and `main.go` share the same route registration
- keep PR scoped to the e2e harness only

## Testing
- `go test . ./routes`
- `TALKTOCOW_E2E=1 go test . -run TestBackendE2EAuthFilesAndDiary -count=1 -v`

Note: full `go test ./...` is still blocked locally by missing `dropdb` for generated model tests.
