### PR TITLE
Allow editing recent diary entry dates

### DIFF
--- a/frontend/__tests__/diary-entry-date.test.ts
+++ b/frontend/__tests__/diary-entry-date.test.ts
@@ -1,0 +1,16 @@
+import { createdAtFromDiaryDateInputValue, dateInputValueFromDiaryDate, isDiaryDateEditable } from "../src/components/diary/diary-entry-date"
+
+it("formats diary timestamps for date inputs", () => {
+    expect(dateInputValueFromDiaryDate("2026-05-10T12:00:00Z")).toBe("2026-05-10")
+})
+
+it("creates diary timestamps from date input values", () => {
+    expect(createdAtFromDiaryDateInputValue("2026-05-10")).toBe("2026-05-10T12:00:00Z")
+})
+
+it("allows editing dates for diary entries less than seven days old", () => {
+    const now = new Date("2026-05-12T12:00:00Z")
+
+    expect(isDiaryDateEditable("2026-05-05T12:01:00Z", now)).toBe(true)
+    expect(isDiaryDateEditable("2026-05-05T12:00:00Z", now)).toBe(false)
+})

--- a/frontend/pages/diary/entry/[diaryEntryId].tsx
+++ b/frontend/pages/diary/entry/[diaryEntryId].tsx
@@ -3,6 +3,7 @@ import { getJson, putJson } from "../../../src/api-methods"
 
 import { useNavigate, useParams } from "react-router-dom"
 import { PageContainer } from "../../../src/components/page-container"
+import { createdAtFromDiaryDateInputValue, dateInputValueFromDiaryDate, isDiaryDateEditable } from "../../../src/components/diary/diary-entry-date"
 import { createDiaryBodyFromPlainTextAndImages, DiaryLexicalEditor, getDiaryBodyFileIds, isStructuredDiaryBody } from "../../../src/components/diary/lexical-diary"
 import styles from "../../../src/components/diary/diary.module.css"
 
@@ -18,6 +19,8 @@ export default function DiaryEntryPage() {
     const { diaryEntryId } = useParams()
 
     const [entry, setEntry] = useState<any>()
+    const [entryDate, setEntryDate] = useState("")
+    const [originalEntryDate, setOriginalEntryDate] = useState("")
     const [isSaving, setIsSaving] = useState(false)
     const [saveError, setSaveError] = useState("")
 
@@ -33,6 +36,10 @@ export default function DiaryEntryPage() {
                 setEntry(loadedEntry)
                 return
             }
+
+            const loadedEntryDate = dateInputValueFromDiaryDate(loadedEntry.createdAt)
+            setEntryDate(loadedEntryDate)
+            setOriginalEntryDate(loadedEntryDate)
 
             setEntry({
                 ...loadedEntry,
@@ -52,15 +59,24 @@ export default function DiaryEntryPage() {
             return
         }
 
+        const canEditDate = entry.canEditDate ?? isDiaryDateEditable(entry.createdAt)
+        const mask = ["title", "body", "label", "pictureFileIds"]
+        const updatedCreatedAt = createdAtFromDiaryDateInputValue(entryDate)
+
+        if (canEditDate && entryDate !== originalEntryDate && updatedCreatedAt) {
+            mask.push("createdAt")
+        }
+
         setIsSaving(true)
         setSaveError("")
 
-        putJson("/api/diary/entry/" + diaryEntryId, {
+        putJson<any>("/api/diary/entry/" + diaryEntryId, {
             title: entry.title,
             body: entry.body,
+            createdAt: updatedCreatedAt,
             label: entry.label || undefined,
             pictureFileIds: getDiaryBodyFileIds(entry.body ?? ""),
-            mask: ["title", "body", "label", "pictureFileIds"]
+            mask
         }).then(r => {
             if (r.error) {
                 setSaveError(r.error.message)
@@ -69,6 +85,9 @@ export default function DiaryEntryPage() {
 
             if (r.payload) {
                 setEntry(r.payload)
+                const savedEntryDate = dateInputValueFromDiaryDate(r.payload.createdAt)
+                setEntryDate(savedEntryDate)
+                setOriginalEntryDate(savedEntryDate)
             }
         }).finally(() => {
             setIsSaving(false)
@@ -93,6 +112,19 @@ export default function DiaryEntryPage() {
 
                     {entry && (
                         <div className={styles.draftForm}>
+                            <label className={styles.draftField}>
+                                <span>Entry date</span>
+                                <input
+                                    className={styles.datePicker}
+                                    disabled={!(entry.canEditDate ?? isDiaryDateEditable(entry.createdAt))}
+                                    type="date"
+                                    value={entryDate}
+                                    onChange={e => setEntryDate(e.target.value)}
+                                />
+                                {!(entry.canEditDate ?? isDiaryDateEditable(entry.createdAt)) && (
+                                    <span className={styles.fieldHint}>Dates can only be changed during the first 7 days.</span>
+                                )}
+                            </label>
                             <label className={styles.draftField}>
                                 <span>Title</span>
                                 <input

--- a/frontend/src/components/diary/diary-entry-date.ts
+++ b/frontend/src/components/diary/diary-entry-date.ts
@@ -1,0 +1,33 @@
+const diaryDateEditWindowMs = 7 * 24 * 60 * 60 * 1000
+
+export const dateInputValueFromDiaryDate = (value?: string | null) => {
+    if (!value) {
+        return ""
+    }
+
+    const date = new Date(value)
+
+    if (Number.isNaN(date.getTime())) {
+        return ""
+    }
+
+    return date.toISOString().slice(0, 10)
+}
+
+export const createdAtFromDiaryDateInputValue = (value: string) => {
+    return value ? `${value}T12:00:00Z` : undefined
+}
+
+export const isDiaryDateEditable = (createdAt?: string | null, now: Date = new Date()) => {
+    if (!createdAt) {
+        return false
+    }
+
+    const date = new Date(createdAt)
+
+    if (Number.isNaN(date.getTime())) {
+        return false
+    }
+
+    return now.getTime() - date.getTime() < diaryDateEditWindowMs
+}

--- a/frontend/src/components/diary/diary.module.css
+++ b/frontend/src/components/diary/diary.module.css
@@ -131,6 +131,18 @@
     box-shadow: 0 0 0 4px rgba(140, 99, 179, 0.16);
 }
 
+.draftField input:disabled {
+    background: #f3f4f6;
+    color: #667085;
+    cursor: not-allowed;
+}
+
+.fieldHint {
+    color: #667085;
+    font-size: 13px;
+    font-weight: 700;
+}
+
 .titleInput {
     color: #5b2b82 !important;
     font-size: 24px !important;

--- a/routes/diary.go
+++ b/routes/diary.go
@@ -16,6 +16,7 @@ type DiaryEntry struct {
 	Body           string  `json:"body"`
 	PostedByUserID string  `json:"postedByUserId"`
 	CreateAt       string  `json:"createdAt"`
+	CanEditDate    bool    `json:"canEditDate"`
 	Label          *string `json:"label"`
 	PictureCount   int     `json:"pictureCount"`
 }
@@ -41,11 +42,19 @@ type CreateDiaryEntryRequest struct {
 type UpdateDiaryEntryRequest struct {
 	Title          string   `json:"title"`
 	Body           string   `json:"body"`
+	CreatedAt      string   `json:"createdAt"`
 	Offset         int      `json:"offset"`
 	Mask           []string `json:"mask"`
 	Label          *string  `json:"label"`
 	PictureFileIDs []int    `json:"pictureFileIds"`
 }
+
+const diaryEntryDateEditWindow = 7 * 24 * time.Hour
+
+var (
+	errDiaryEntryDateEditExpired = errors.New("diary entry date edit window expired")
+	errInvalidDiaryEntryDate     = errors.New("invalid diary entry date")
+)
 
 func parseDiaryTime(value string) (time.Time, error) {
 	if parsed, err := time.Parse(time.RFC3339, value); err == nil {
@@ -61,6 +70,23 @@ func parseDiaryTime(value string) (time.Time, error) {
 
 func formatDiaryTime(value time.Time) string {
 	return value.Format(time.RFC3339)
+}
+
+func canEditDiaryEntryDate(createdAt time.Time, now time.Time) bool {
+	return now.Sub(createdAt) < diaryEntryDateEditWindow
+}
+
+func validateDiaryEntryDateEdit(existingCreatedAt time.Time, requestedCreatedAt string, now time.Time) (time.Time, error) {
+	if !canEditDiaryEntryDate(existingCreatedAt, now) {
+		return time.Time{}, errDiaryEntryDateEditExpired
+	}
+
+	parsed, err := parseDiaryTime(requestedCreatedAt)
+	if err != nil {
+		return time.Time{}, errInvalidDiaryEntryDate
+	}
+
+	return parsed, nil
 }
 
 func scanDiaryEntry(scanner interface {
@@ -91,6 +117,7 @@ func scanDiaryEntry(scanner interface {
 	entry.Body = body.String
 	entry.PostedByUserID = strconv.Itoa(postedByUserID)
 	entry.CreateAt = formatDiaryTime(createdAt)
+	entry.CanEditDate = canEditDiaryEntryDate(createdAt, time.Now())
 
 	if label.Valid {
 		entry.Label = &label.String
@@ -194,6 +221,7 @@ func GetDiaryEntry(ctx *gin.Context) {
 
 func UpdateDiaryEntry(ctx *gin.Context) {
 	db := GetDBFromContext(ctx)
+	userSession := GetUserSessionFromContext(ctx)
 
 	entryId, err := strconv.Atoi(ctx.Params.ByName("diaryEntryId"))
 
@@ -216,17 +244,60 @@ func UpdateDiaryEntry(ctx *gin.Context) {
 	}
 	defer tx.Rollback()
 
+	var postedByUserID int
+	var existingCreatedAt time.Time
+
+	err = tx.QueryRowContext(ctx.Request.Context(), `
+		select who_posted_user_id, created_at
+		from diary_entries
+		where id = $1
+	`, entryId).Scan(&postedByUserID, &existingCreatedAt)
+
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			ctx.JSON(http.StatusNotFound, CreateErrorResponse(NotFound, "Diary entry not found"))
+			return
+		}
+
+		ctx.JSON(http.StatusInternalServerError, CreateErrorResponse(InternalServerError, "Failed to update diary entry"))
+		return
+	}
+
+	if postedByUserID != int(userSession.UserID) {
+		ctx.JSON(http.StatusForbidden, CreateErrorResponse(AuthorizationError, "Only the author can edit this diary entry"))
+		return
+	}
+
+	shouldUpdateCreatedAt := DoesMaskHaveField(updateDiaryEntryRequest.Mask, "createdAt")
+	updatedCreatedAt := time.Time{}
+
+	if shouldUpdateCreatedAt {
+		updatedCreatedAt, err = validateDiaryEntryDateEdit(existingCreatedAt, updateDiaryEntryRequest.CreatedAt, time.Now())
+
+		if err != nil {
+			if errors.Is(err, errDiaryEntryDateEditExpired) {
+				ctx.JSON(http.StatusForbidden, CreateErrorResponse(AuthorizationError, "Diary entry dates can only be changed during the first 7 days"))
+				return
+			}
+
+			ctx.JSON(http.StatusBadRequest, CreateErrorResponse(InvalidInput, "Invalid diary entry date"))
+			return
+		}
+	}
+
 	_, err = tx.ExecContext(ctx.Request.Context(), `
 		update diary_entries
 		set title = case when $2 then $3 else title end,
 		    body = case when $4 then $5 else body end,
-		    label = case when $6 then $7 else label end
+		    label = case when $6 then $7 else label end,
+		    created_at = case when $8 then $9 else created_at end
 		where id = $1
 	`,
 		entryId,
 		DoesMaskHaveField(updateDiaryEntryRequest.Mask, "title"), updateDiaryEntryRequest.Title,
 		DoesMaskHaveField(updateDiaryEntryRequest.Mask, "body"), updateDiaryEntryRequest.Body,
 		DoesMaskHaveField(updateDiaryEntryRequest.Mask, "label"), updateDiaryEntryRequest.Label,
+		shouldUpdateCreatedAt, updatedCreatedAt,
 	)
 
 	if err != nil {

--- a/routes/diary_test.go
+++ b/routes/diary_test.go
@@ -1,0 +1,44 @@
+package routes
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestValidateDiaryEntryDateEditAllowsEntriesLessThanSevenDaysOld(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	existingCreatedAt := now.Add(-(6*24*time.Hour + 23*time.Hour + 59*time.Minute))
+
+	parsed, err := validateDiaryEntryDateEdit(existingCreatedAt, "2026-05-10", now)
+
+	if err != nil {
+		t.Fatalf("expected date edit to be valid, got %v", err)
+	}
+
+	if parsed.Format("2006-01-02") != "2026-05-10" {
+		t.Fatalf("expected parsed date 2026-05-10, got %s", parsed.Format("2006-01-02"))
+	}
+}
+
+func TestValidateDiaryEntryDateEditRejectsEntriesSevenDaysOld(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	existingCreatedAt := now.Add(-7 * 24 * time.Hour)
+
+	_, err := validateDiaryEntryDateEdit(existingCreatedAt, "2026-05-10", now)
+
+	if !errors.Is(err, errDiaryEntryDateEditExpired) {
+		t.Fatalf("expected expired date edit error, got %v", err)
+	}
+}
+
+func TestValidateDiaryEntryDateEditRejectsInvalidDates(t *testing.T) {
+	now := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	existingCreatedAt := now.Add(-24 * time.Hour)
+
+	_, err := validateDiaryEntryDateEdit(existingCreatedAt, "not-a-date", now)
+
+	if !errors.Is(err, errInvalidDiaryEntryDate) {
+		t.Fatalf("expected invalid date error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow diary entry dates to be edited from the entry editor while the entry is less than 7 days old
- enforce the 7-day edit window server-side and expose canEditDate in diary entry responses
- add focused backend and frontend tests for date edit eligibility/parsing

## Verification
- go test ./routes
- npm run lint
- npm test
- npm run build

Note: full `go test ./...` currently fails because `dropdb` is not installed in this environment for the models test setup.