### PR TITLE
Fix diary image loading across users

### DIFF
--- a/backend_e2e_test.go
+++ b/backend_e2e_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 type e2eHarness struct {
-	t      *testing.T
-	db     *sql.DB
-	server http.Handler
-	userID int
+	t       *testing.T
+	db      *sql.DB
+	server  http.Handler
+	userIDs []int
 }
 
 func TestBackendE2EAuthFilesAndDiary(t *testing.T) {
@@ -113,6 +113,57 @@ func TestBackendE2EAuthFilesAndDiary(t *testing.T) {
 	}
 }
 
+func TestBackendE2EDiaryImageVisibleToOtherAuthenticatedUser(t *testing.T) {
+	if os.Getenv("TALKTOCOW_E2E") != "1" {
+		t.Skip("set TALKTOCOW_E2E=1 to run backend e2e tests against the configured Postgres database")
+	}
+
+	h := newE2EHarness(t)
+	defer h.cleanup()
+
+	stamp := time.Now().UnixNano()
+	ownerUsername := fmt.Sprintf("e2e_owner_%d", stamp)
+	viewerUsername := fmt.Sprintf("e2e_viewer_%d", stamp)
+	password := "test-password"
+	h.createUser(ownerUsername, password)
+	h.createUser(viewerUsername, password)
+
+	ownerCookies := h.loginCookies(ownerUsername, password)
+	viewerCookies := h.loginCookies(viewerUsername, password)
+
+	fileID := h.uploadJPEGWithCookies(ownerCookies)
+	diary := h.jsonRequest("POST", "/api/diary/entry", map[string]any{
+		"title":          "E2E shared diary image",
+		"body":           "Uploaded by one user and viewed by another",
+		"createdAt":      "2026-05-13T05:00:00Z",
+		"pictureFileIds": []int{fileID},
+	}, ownerCookies)
+	assertStatus(t, diary, http.StatusOK)
+
+	entryID, err := strconv.Atoi(jsonField(t, diary.Body.Bytes(), "id"))
+	if err != nil || entryID == 0 {
+		t.Fatalf("parse created diary entry id: %v; body=%s", err, diary.Body.String())
+	}
+
+	entryAsViewer := h.request("GET", fmt.Sprintf("/api/diary/entry/%d", entryID), nil, nil, viewerCookies...)
+	assertStatus(t, entryAsViewer, http.StatusOK)
+	if got := jsonField(t, entryAsViewer.Body.Bytes(), "pictureCount"); got != "1" {
+		t.Fatalf("viewer diary pictureCount = %q, want 1; body=%s", got, entryAsViewer.Body.String())
+	}
+
+	picturesAsViewer := h.request("GET", fmt.Sprintf("/api/diary/entry/%d/pictures", entryID), nil, nil, viewerCookies...)
+	assertStatus(t, picturesAsViewer, http.StatusOK)
+
+	imageAsViewer := h.request("GET", fmt.Sprintf("/api/files/%d?size=medium", fileID), nil, nil, viewerCookies...)
+	assertStatus(t, imageAsViewer, http.StatusOK)
+	if contentType := imageAsViewer.Header().Get("Content-Type"); contentType != "image/jpeg" {
+		t.Fatalf("viewer image content type = %q, want image/jpeg", contentType)
+	}
+	if imageAsViewer.Body.Len() == 0 {
+		t.Fatalf("viewer image response was empty")
+	}
+}
+
 func newE2EHarness(t *testing.T) *e2eHarness {
 	t.Helper()
 
@@ -150,28 +201,48 @@ func (h *e2eHarness) createUser(username, password string) {
 		h.t.Fatalf("hash password: %v", err)
 	}
 
+	var userID int
 	err = h.db.QueryRowContext(context.Background(), `
 		insert into users (name, username, password_hash, created_at)
 		values ($1, $1, $2, now())
 		returning id
-	`, username, hash).Scan(&h.userID)
+	`, username, hash).Scan(&userID)
 	if err != nil {
 		h.t.Fatalf("insert e2e user: %v", err)
 	}
+	h.userIDs = append(h.userIDs, userID)
 }
 
 func (h *e2eHarness) cleanup() {
-	if h.userID == 0 {
+	if len(h.userIDs) == 0 {
 		return
 	}
 
 	ctx := context.Background()
-	_, _ = h.db.ExecContext(ctx, `delete from diary_entry_comments where user_id = $1`, h.userID)
-	_, _ = h.db.ExecContext(ctx, `delete from diary_entry_pictures where diary_entry_id in (select id from diary_entries where user_id = $1)`, h.userID)
-	_, _ = h.db.ExecContext(ctx, `delete from shared_diary_entries where diary_entry_id in (select id from diary_entries where user_id = $1)`, h.userID)
-	_, _ = h.db.ExecContext(ctx, `delete from diary_entries where user_id = $1`, h.userID)
-	_, _ = h.db.ExecContext(ctx, `delete from files where uploaded_by_user_id = $1`, h.userID)
-	_, _ = h.db.ExecContext(ctx, `delete from users where id = $1`, h.userID)
+	for _, userID := range h.userIDs {
+		_, _ = h.db.ExecContext(ctx, `delete from diary_entry_comments where user_id = $1`, userID)
+		_, _ = h.db.ExecContext(ctx, `delete from diary_entry_pictures where diary_entry_id in (select id from diary_entries where who_posted_user_id = $1)`, userID)
+		_, _ = h.db.ExecContext(ctx, `delete from shared_diary_entries where diary_entry_id in (select id from diary_entries where who_posted_user_id = $1)`, userID)
+		_, _ = h.db.ExecContext(ctx, `delete from diary_entries where who_posted_user_id = $1`, userID)
+		_, _ = h.db.ExecContext(ctx, `delete from files where uploaded_by_user_id = $1`, userID)
+		_, _ = h.db.ExecContext(ctx, `delete from users where id = $1`, userID)
+	}
+}
+
+func (h *e2eHarness) loginCookies(username, password string) []*http.Cookie {
+	h.t.Helper()
+
+	response := h.jsonRequest("POST", "/api/login", map[string]string{
+		"username": username,
+		"password": password,
+	}, nil)
+	assertStatus(h.t, response, http.StatusOK)
+
+	cookies := response.Result().Cookies()
+	if len(cookies) == 0 {
+		h.t.Fatalf("/api/login did not set an auth cookie for %s", username)
+	}
+	return cookies
 }
 
 func (h *e2eHarness) jsonRequest(method, path string, body any, cookies []*http.Cookie) *httptest.ResponseRecorder {
@@ -223,6 +294,34 @@ func (h *e2eHarness) uploadJPEGWithBearer(token string) int {
 		"Authorization": "Bearer " + token,
 		"Content-Type":  writer.FormDataContentType(),
 	})
+	assertStatus(h.t, response, http.StatusOK)
+
+	fileID, err := strconv.Atoi(jsonField(h.t, response.Body.Bytes(), "id"))
+	if err != nil {
+		h.t.Fatalf("parse uploaded file id: %v; body=%s", err, response.Body.String())
+	}
+	return fileID
+}
+
+func (h *e2eHarness) uploadJPEGWithCookies(cookies []*http.Cookie) int {
+	h.t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "diary.jpg")
+	if err != nil {
+		h.t.Fatalf("create multipart file: %v", err)
+	}
+	if _, err := part.Write(orientedJPEGFixture(h.t)); err != nil {
+		h.t.Fatalf("write multipart file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		h.t.Fatalf("close multipart writer: %v", err)
+	}
+
+	response := h.request("POST", "/api/files", &body, map[string]string{
+		"Content-Type": writer.FormDataContentType(),
+	}, cookies...)
 	assertStatus(h.t, response, http.StatusOK)
 
 	fileID, err := strconv.Atoi(jsonField(h.t, response.Body.Bytes(), "id"))

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,3 +30,20 @@ sudo systemctl status talktocow-backend talktocow-frontend
 sudo journalctl -u talktocow-backend -f
 sudo journalctl -u talktocow-frontend -f
 ```
+
+## nginx reverse proxy
+
+If Talktocow is served through nginx, raise nginx's default request body limit so browser image uploads can reach the backend. The app still enforces its own per-file upload limit.
+
+Use `deploy/nginx-talktocow.conf` as a starting point, or add this inside the HTTPS `server` block:
+
+```nginx
+client_max_body_size 16m;
+```
+
+Then validate and reload nginx:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```

--- a/deploy/nginx-talktocow.conf
+++ b/deploy/nginx-talktocow.conf
@@ -1,0 +1,50 @@
+# Example nginx reverse proxy for Talktocow.
+# Adjust server_name and certificate paths for the target host.
+
+server {
+    listen 80;
+    server_name talktocow.example.test;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name talktocow.example.test;
+
+    ssl_certificate /etc/letsencrypt/live/talktocow.example.test/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/talktocow.example.test/privkey.pem;
+
+    # Browser image uploads are multipart requests and can exceed nginx's
+    # 1 MB default. The backend still enforces its own per-file upload limit.
+    client_max_body_size 16m;
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:12001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /ws {
+        proxy_pass http://127.0.0.1:12001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/frontend/__tests__/diary-image-source.test.ts
+++ b/frontend/__tests__/diary-image-source.test.ts
@@ -1,0 +1,19 @@
+import { diaryFileImageUrl, diaryFileUrl, diaryImageSource, diaryImageVariantUrl } from "../src/components/diary/diary-image-source"
+
+it("builds diary file image variants", () => {
+    expect(diaryFileUrl(42)).toBe("/api/files/42")
+    expect(diaryFileImageUrl(42, "large")).toBe("/api/files/42?size=large")
+})
+
+it("does not put auth tokens into diary image URLs", () => {
+    expect(diaryImageSource(diaryImageVariantUrl("/api/files/42", "large"))).toBe("/api/files/42?size=large")
+})
+
+it("preserves file-like browser URLs instead of appending server-only params", () => {
+    expect(diaryImageVariantUrl("blob:http://localhost/image-id", "large")).toBe("blob:http://localhost/image-id")
+    expect(diaryImageSource("file:///tmp/upload.jpg")).toBe("file:///tmp/upload.jpg")
+})
+
+it("keeps absolute API file URLs absolute without adding auth params", () => {
+    expect(diaryImageSource(diaryImageVariantUrl("https://api.example.test/api/files/42", "thumb"))).toBe("https://api.example.test/api/files/42?size=thumb")
+})

--- a/frontend/src/components/diary/diary-entry.tsx
+++ b/frontend/src/components/diary/diary-entry.tsx
@@ -3,9 +3,9 @@ import React, { useCallback, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { deleteJson, getJson, postJson } from "../../api-methods";
 import { getSession } from "../../logic/session-manager";
-import { resolveServerUrl } from "../../utility";
 import { DiaryBodyRenderer, isStructuredDiaryBody } from "./lexical-diary";
 import { Modal } from "../modal";
+import { diaryFileUrl, diaryImageSource, diaryImageVariantUrl } from "./diary-image-source";
 import styles from "./diary-entry.module.css";
 
 type DiaryEntryPicture = {
@@ -13,15 +13,6 @@ type DiaryEntryPicture = {
     fileId: number
     fileName: string
     url: string
-}
-
-const pictureSource = (url: string) => {
-    return resolveServerUrl(url)
-}
-
-const pictureVariantUrl = (url: string, size: "thumb" | "large") => {
-    const separator = url.includes("?") ? "&" : "?"
-    return `${url}${separator}size=${size}`
 }
 
 export const DiaryEntry = (props: {
@@ -135,14 +126,14 @@ export const DiaryEntry = (props: {
                     id: image.fileId,
                     fileId: image.fileId,
                     fileName: image.alt ?? "Diary image",
-                    url: `/api/files/${image.fileId}`
+                    url: diaryFileUrl(image.fileId)
                 })}
             />
             {!bodyIsStructured && pictures.length > 0 && (
                 <div className={styles.pictureGrid}>
                     {pictures.map(picture => (
                         <button className={styles.pictureButton} onClick={() => setPreviewPicture(picture)} key={picture.id} type="button">
-                            <img src={pictureSource(pictureVariantUrl(picture.url, "thumb"))} alt={picture.fileName} />
+                            <img src={diaryImageSource(diaryImageVariantUrl(picture.url, "thumb"))} alt={picture.fileName} />
                         </button>
                     ))}
                 </div>
@@ -195,7 +186,7 @@ export const DiaryEntry = (props: {
             {previewPicture && (
                 <div className={styles.fullscreenPreview} onClick={() => setPreviewPicture(null)}>
                     <button className={styles.closePreviewButton} onClick={() => setPreviewPicture(null)} type="button">×</button>
-                    <img src={pictureSource(pictureVariantUrl(previewPicture.url, "large"))} alt={previewPicture.fileName} onClick={event => event.stopPropagation()} />
+                    <img src={diaryImageSource(diaryImageVariantUrl(previewPicture.url, "large"))} alt={previewPicture.fileName} onClick={event => event.stopPropagation()} />
                 </div>
             )}
         </div>

--- a/frontend/src/components/diary/diary-image-source.ts
+++ b/frontend/src/components/diary/diary-image-source.ts
@@ -1,0 +1,39 @@
+import { resolveServerUrl } from "../../utility"
+
+export type DiaryImageSize = "thumb" | "medium" | "large" | "original"
+
+const externalSchemePattern = /^[a-z][a-z\d+\-.]*:/i
+const passthroughSchemePattern = /^(blob|data|file):/i
+
+const canAppendServerImageParams = (url: string) => !passthroughSchemePattern.test(url)
+
+const appendQueryParam = (url: string, name: string, value?: string) => {
+    if (!value || !canAppendServerImageParams(url)) {
+        return url
+    }
+
+    const hashIndex = url.indexOf("#")
+    const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex)
+    const hash = hashIndex === -1 ? "" : url.slice(hashIndex)
+    const separator = beforeHash.includes("?") ? "&" : "?"
+
+    return `${beforeHash}${separator}${encodeURIComponent(name)}=${encodeURIComponent(value)}${hash}`
+}
+
+export const diaryFileUrl = (fileId: number) => `/api/files/${fileId}`
+
+export const diaryImageVariantUrl = (url: string, size: DiaryImageSize) => {
+    return appendQueryParam(url, "size", size)
+}
+
+export const diaryFileImageUrl = (fileId: number, size: DiaryImageSize = "medium") => {
+    return diaryImageVariantUrl(diaryFileUrl(fileId), size)
+}
+
+export const diaryImageSource = (url: string) => {
+    if (externalSchemePattern.test(url)) {
+        return url
+    }
+
+    return resolveServerUrl(url)
+}

--- a/frontend/src/components/diary/lexical-diary.tsx
+++ b/frontend/src/components/diary/lexical-diary.tsx
@@ -24,8 +24,7 @@ import {
     Spread
 } from "lexical"
 import { postFormData } from "../../api-methods"
-import { getSession } from "../../logic/session-manager"
-import { resolveServerUrl } from "../../utility"
+import { diaryFileImageUrl, diaryImageSource } from "./diary-image-source"
 import {
     DIARY_RICH_TEXT_DOCUMENT_VERSION,
     DiaryRichTextBlock,
@@ -54,12 +53,6 @@ type SerializedDiaryImageNode = Spread<{
     fileId: number
     src: string
 }, SerializedLexicalNode>
-
-const pictureSource = (url: string) => {
-    const token = getSession().token
-    const separator = url.includes("?") ? "&" : "?"
-    return resolveServerUrl(token ? `${url}${separator}token=${encodeURIComponent(token)}` : url)
-}
 
 export class DiaryImageNode extends DecoratorNode<React.ReactNode> {
     __fileId: number
@@ -128,7 +121,7 @@ function EditableDiaryImage(props: {
 
     return (
         <div className={styles.editableImageFrame}>
-            <img className={styles.inlineImage} src={pictureSource(fileUrl(props.fileId))} alt={props.alt} />
+            <img className={styles.inlineImage} src={diaryImageSource(diaryFileImageUrl(props.fileId))} alt={props.alt} />
             <button
                 aria-label="Remove picture"
                 className={styles.removeImageButton}
@@ -149,7 +142,6 @@ function $createDiaryImageNode(payload: {
     return $applyNodeReplacement(new DiaryImageNode(payload.fileId, payload.src, payload.alt))
 }
 
-const fileUrl = (fileId: number, size: "thumb" | "medium" | "large" | "original" = "medium") => `/api/files/${fileId}?size=${size}`
 const maxImageDimension = 1600
 const imageUploadQuality = 0.82
 
@@ -354,7 +346,7 @@ const lexicalStateFromDiaryDocument = (document: DiaryRichTextDocument) => {
             return {
                 alt: block.alt ?? "",
                 fileId: block.fileId,
-                src: fileUrl(block.fileId),
+                src: diaryFileImageUrl(block.fileId),
                 type: "diary-image",
                 version: 1
             }
@@ -590,7 +582,7 @@ function DiaryToolbarPlugin(props: {
                             $createDiaryImageNode({
                                 alt: response.payload?.fileName ?? file.name,
                                 fileId: response.payload.id,
-                                src: fileUrl(response.payload.id)
+                                src: diaryFileImageUrl(response.payload.id)
                             }),
                             $createParagraphNode()
                         ])
@@ -702,7 +694,7 @@ function DiaryImageDropPlugin() {
                             $createDiaryImageNode({
                                 alt: response.payload?.fileName ?? file.name,
                                 fileId: response.payload.id,
-                                src: fileUrl(response.payload.id)
+                                src: diaryFileImageUrl(response.payload.id)
                             }),
                             $createParagraphNode()
                         ])
@@ -856,7 +848,7 @@ const renderInlineNode = (node: DiaryRichTextInlineNode, key: string) => {
 
 const renderBlock = (block: DiaryRichTextBlock, key: string, onImageClick?: (image: { alt?: string, fileId: number }) => void): React.ReactNode => {
     if (block.type === "image") {
-        const image = <img className={styles.inlineImage} src={pictureSource(fileUrl(block.fileId))} alt={block.alt ?? ""} />
+        const image = <img className={styles.inlineImage} src={diaryImageSource(diaryFileImageUrl(block.fileId))} alt={block.alt ?? ""} />
 
         return (
             <figure className={styles.readonlyImageFrame} key={key}>


### PR DESCRIPTION
## Summary
- stop adding auth tokens to diary image URLs; same-origin image requests now rely on the auth cookie
- centralize diary image URL/variant generation with regression tests
- add backend e2e coverage for user A uploading a diary image and user B viewing it with their own auth cookie
- document nginx `client_max_body_size` for image uploads and add an example reverse proxy config

## Testing
- `go test . ./routes`
- `TALKTOCOW_E2E=1 go test . -run 'TestBackendE2E(AuthFilesAndDiary|DiaryImageVisibleToOtherAuthenticatedUser)' -count=1 -v`
- `npm run lint`
- `npm test`
- `npm run build`

Note: full `go test ./...` is still blocked locally by missing `dropdb` for generated model tests.
