### PR TITLE
Fix cross-origin diary image auth

### DIFF
--- a/frontend/__tests__/diary-image-source.test.ts
+++ b/frontend/__tests__/diary-image-source.test.ts
@@ -5,15 +5,16 @@ it("builds diary file image variants", () => {
     expect(diaryFileImageUrl(42, "large")).toBe("/api/files/42?size=large")
 })
 
-it("does not put auth tokens into diary image URLs", () => {
-    expect(diaryImageSource(diaryImageVariantUrl("/api/files/42", "large"))).toBe("/api/files/42?size=large")
+it("does not put auth tokens into same-origin diary image URLs", () => {
+    expect(diaryImageSource(diaryImageVariantUrl("/api/files/42", "large"), "token value", "https://app.example.test")).toBe("/api/files/42?size=large")
+    expect(diaryImageSource("https://app.example.test/api/files/42?size=medium", "token value", "https://app.example.test")).toBe("https://app.example.test/api/files/42?size=medium")
+})
+
+it("adds the token to cross-origin diary image URLs", () => {
+    expect(diaryImageSource(diaryImageVariantUrl("https://api.example.test/api/files/42", "thumb"), "token value", "https://app.example.test")).toBe("https://api.example.test/api/files/42?size=thumb&token=token%20value")
 })
 
 it("preserves file-like browser URLs instead of appending server-only params", () => {
     expect(diaryImageVariantUrl("blob:http://localhost/image-id", "large")).toBe("blob:http://localhost/image-id")
-    expect(diaryImageSource("file:///tmp/upload.jpg")).toBe("file:///tmp/upload.jpg")
-})
-
-it("keeps absolute API file URLs absolute without adding auth params", () => {
-    expect(diaryImageSource(diaryImageVariantUrl("https://api.example.test/api/files/42", "thumb"))).toBe("https://api.example.test/api/files/42?size=thumb")
+    expect(diaryImageSource("file:///tmp/upload.jpg", "token value", "https://app.example.test")).toBe("file:///tmp/upload.jpg")
 })

--- a/frontend/src/components/diary/diary-image-source.ts
+++ b/frontend/src/components/diary/diary-image-source.ts
@@ -1,3 +1,4 @@
+import { getSession } from "../../logic/session-manager"
 import { resolveServerUrl } from "../../utility"
 
 export type DiaryImageSize = "thumb" | "medium" | "large" | "original"
@@ -20,6 +21,18 @@ const appendQueryParam = (url: string, name: string, value?: string) => {
     return `${beforeHash}${separator}${encodeURIComponent(name)}=${encodeURIComponent(value)}${hash}`
 }
 
+const isCrossOriginUrl = (url: string, currentOrigin = globalThis.location?.origin) => {
+    if (!currentOrigin || !canAppendServerImageParams(url)) {
+        return false
+    }
+
+    try {
+        return new URL(url, currentOrigin).origin !== currentOrigin
+    } catch (_error) {
+        return false
+    }
+}
+
 export const diaryFileUrl = (fileId: number) => `/api/files/${fileId}`
 
 export const diaryImageVariantUrl = (url: string, size: DiaryImageSize) => {
@@ -30,10 +43,12 @@ export const diaryFileImageUrl = (fileId: number, size: DiaryImageSize = "medium
     return diaryImageVariantUrl(diaryFileUrl(fileId), size)
 }
 
-export const diaryImageSource = (url: string) => {
-    if (externalSchemePattern.test(url)) {
-        return url
+export const diaryImageSource = (url: string, token = getSession().token, currentOrigin?: string) => {
+    const resolvedUrl = externalSchemePattern.test(url) ? url : resolveServerUrl(url)
+
+    if (!isCrossOriginUrl(resolvedUrl, currentOrigin)) {
+        return resolvedUrl
     }
 
-    return resolveServerUrl(url)
+    return appendQueryParam(resolvedUrl, "token", token)
 }


### PR DESCRIPTION
## Summary
- keep same-origin diary image URLs clean so they rely on the auth cookie
- restore `token=` fallback only for cross-origin file URLs, where browser subresource requests may not include the auth cookie
- update diary image source tests for same-origin, cross-origin, and file/blob URL behavior

## Testing
- `go test . ./routes`
- `TALKTOCOW_E2E=1 go test . -run 'TestBackendE2E(AuthFilesAndDiary|DiaryImageVisibleToOtherAuthenticatedUser)' -count=1 -v`
- `npm run lint`
- `npm test`
- `npm run build`
