### PR TITLE
Use cookies for same-origin diary images

### DIFF
--- a/frontend/src/components/diary/diary-image-source.ts
+++ b/frontend/src/components/diary/diary-image-source.ts
@@ -7,6 +7,7 @@ const externalSchemePattern = /^[a-z][a-z\d+\-.]*:/i
 const passthroughSchemePattern = /^(blob|data|file):/i
 
 const canAppendServerImageParams = (url: string) => !passthroughSchemePattern.test(url)
+const isRootRelativeUrl = (url: string) => url.startsWith("/")
 
 const appendQueryParam = (url: string, name: string, value?: string) => {
     if (!value || !canAppendServerImageParams(url)) {
@@ -44,7 +45,7 @@ export const diaryFileImageUrl = (fileId: number, size: DiaryImageSize = "medium
 }
 
 export const diaryImageSource = (url: string, token = getSession().token, currentOrigin?: string) => {
-    const resolvedUrl = externalSchemePattern.test(url) ? url : resolveServerUrl(url)
+    const resolvedUrl = externalSchemePattern.test(url) || isRootRelativeUrl(url) ? url : resolveServerUrl(url)
 
     if (!isCrossOriginUrl(resolvedUrl, currentOrigin)) {
         return resolvedUrl

--- a/routes/session.go
+++ b/routes/session.go
@@ -71,25 +71,21 @@ func authenticateToken(token string, out *UserSession) error {
 	return auth.DecodeObjectFromToken(token, out)
 }
 
-func GetUserSessionFromRequest(ctx *gin.Context) (UserSession, bool) {
-	sources := []struct {
-		name  string
-		token string
-	}{
+type authTokenSource struct {
+	name  string
+	token string
+}
+
+func getUserSessionAndTokenSourceFromRequest(ctx *gin.Context) (UserSession, authTokenSource, bool) {
+	sources := []authTokenSource{
 		{name: "authorization header", token: bearerTokenFromHeader(ctx.GetHeader("authorization"))},
 	}
 
 	if cookie, err := ctx.Request.Cookie(AuthCookieName); err == nil {
-		sources = append(sources, struct {
-			name  string
-			token string
-		}{name: "auth cookie", token: cookie.Value})
+		sources = append(sources, authTokenSource{name: "auth cookie", token: cookie.Value})
 	}
 
-	sources = append(sources, struct {
-		name  string
-		token string
-	}{name: "query token", token: ctx.Query("token")})
+	sources = append(sources, authTokenSource{name: "query token", token: ctx.Query("token")})
 
 	for _, source := range sources {
 		if source.token == "" {
@@ -103,14 +99,19 @@ func GetUserSessionFromRequest(ctx *gin.Context) (UserSession, bool) {
 			continue
 		}
 
-		return userSession, true
+		return userSession, source, true
 	}
 
-	return UserSession{}, false
+	return UserSession{}, authTokenSource{}, false
+}
+
+func GetUserSessionFromRequest(ctx *gin.Context) (UserSession, bool) {
+	userSession, _, ok := getUserSessionAndTokenSourceFromRequest(ctx)
+	return userSession, ok
 }
 
 func SessionMiddleware(ctx *gin.Context) {
-	userSession, ok := GetUserSessionFromRequest(ctx)
+	userSession, tokenSource, ok := getUserSessionAndTokenSourceFromRequest(ctx)
 
 	if !ok {
 		log.Println("User is not authorized")
@@ -119,6 +120,10 @@ func SessionMiddleware(ctx *gin.Context) {
 
 		ctx.Abort()
 		return
+	}
+
+	if tokenSource.name == "authorization header" {
+		SetAuthCookie(ctx, tokenSource.token)
 	}
 
 	ctx.Set("userSession", userSession)


### PR DESCRIPTION
## Summary
- keep root-relative diary image URLs as `/api/files/...` so nginx/Vite proxy deployments use same-origin cookies
- avoid adding `token=` to same-origin image URLs
- refresh the HttpOnly auth cookie when authenticated API requests arrive with a bearer token, so existing localStorage-token sessions can load browser image requests without exposing tokens in URLs
- keep token fallback only for genuinely cross-origin image URLs

## Checks
- go test . ./routes
- frontend npm run lint
- frontend npm test -- diary-image-source
- frontend npm run build