### PR TITLE
Render rich diary previews and creator names

### DIFF
--- a/frontend/src/components/calendar-day-view.module.css
+++ b/frontend/src/components/calendar-day-view.module.css
@@ -344,6 +344,96 @@
     color: #FFFFFF !important;
 }
 
+.labelColorLime {
+    background: #84CC16 !important;
+    color: #111827 !important;
+}
+
+.labelColorTeal {
+    background: #0D9488 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorSky {
+    background: #0284C7 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorIndigo {
+    background: #4F46E5 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorViolet {
+    background: #8B5CF6 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorFuchsia {
+    background: #C026D3 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorRose {
+    background: #E11D48 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorAmber {
+    background: #F59E0B !important;
+    color: #111827 !important;
+}
+
+.labelColorEmerald {
+    background: #059669 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorSlate {
+    background: #334155 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorStone {
+    background: #78716C !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorWine {
+    background: #9F1239 !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorMint {
+    background: #2DD4BF !important;
+    color: #111827 !important;
+}
+
+.labelColorNavy {
+    background: #1E3A8A !important;
+    color: #FFFFFF !important;
+}
+
+.labelColorCoral {
+    background: #FB7185 !important;
+    color: #111827 !important;
+}
+
+.labelColorOlive {
+    background: #65A30D !important;
+    color: #111827 !important;
+}
+
+.labelColorLavender {
+    background: #A78BFA !important;
+    color: #111827 !important;
+}
+
+.labelColorPeach {
+    background: #FDBA74 !important;
+    color: #111827 !important;
+}
+
 .quickAddInputRow {
     display: flex;
     gap: 8px;

--- a/frontend/src/components/calendar-day-view.tsx
+++ b/frontend/src/components/calendar-day-view.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, useSearchParams } from "react-router-dom"
 import { deleteJson, getJson, postJson } from "../api-methods"
+import { DiaryBodyRenderer } from "./diary/lexical-diary"
 import { Modal } from "./modal"
 import styles from "./calendar-day-view.module.css"
 
@@ -52,18 +53,26 @@ const labelColorClasses = [
     styles.labelColorYellow,
     styles.labelColorRed,
     styles.labelColorBrown,
-    styles.labelColorGray
+    styles.labelColorGray,
+    styles.labelColorLime,
+    styles.labelColorTeal,
+    styles.labelColorSky,
+    styles.labelColorIndigo,
+    styles.labelColorViolet,
+    styles.labelColorFuchsia,
+    styles.labelColorRose,
+    styles.labelColorAmber,
+    styles.labelColorEmerald,
+    styles.labelColorSlate,
+    styles.labelColorStone,
+    styles.labelColorWine,
+    styles.labelColorMint,
+    styles.labelColorNavy,
+    styles.labelColorCoral,
+    styles.labelColorOlive,
+    styles.labelColorLavender,
+    styles.labelColorPeach
 ]
-
-const getLabelColorClass = (label: string) => {
-    let hash = 5381
-
-    for (const char of label.toLowerCase()) {
-        hash = ((hash << 5) + hash) ^ char.charCodeAt(0)
-    }
-
-    return labelColorClasses[Math.abs(hash) % labelColorClasses.length]
-}
 
 const getUniqueLabels = (entries: DiaryCalendarEntry[]) => {
     const labels: string[] = []
@@ -75,14 +84,6 @@ const getUniqueLabels = (entries: DiaryCalendarEntry[]) => {
     }
 
     return labels
-}
-
-const getPreview = (body: string) => {
-    if (!body) {
-        return "No details yet."
-    }
-
-    return body.length > 120 ? `${body.slice(0, 120)}…` : body
 }
 
 export const CalendarDayView = () => {
@@ -133,6 +134,22 @@ export const CalendarDayView = () => {
     const selectedEntries = useMemo(() => {
         return entries.filter(entry => entryHappensOnDay(entry, selectedDate))
     }, [entries, selectedDate])
+
+    const labelColorClassByLabel = useMemo(() => {
+        const allLabels = [...labels]
+
+        for (const entry of entries) {
+            if (entry.label && !allLabels.includes(entry.label)) {
+                allLabels.push(entry.label)
+            }
+        }
+
+        return new Map(allLabels.map((label, index) => [label, labelColorClasses[index % labelColorClasses.length]]))
+    }, [entries, labels])
+
+    const getLabelColorClass = useCallback((label: string) => {
+        return labelColorClassByLabel.get(label) ?? labelColorClasses[0]
+    }, [labelColorClassByLabel])
 
     const monthlyLabelCounts = useMemo(() => {
         const counts = new Map<string, number>()
@@ -304,7 +321,11 @@ export const CalendarDayView = () => {
                                 </div>
                                 <div>
                                     <div className={styles.eventTitle}>{entry.title}</div>
-                                    <div className={styles.eventBody}>{getPreview(entry.body)}</div>
+                                    <div className={styles.eventBody}>
+                                        {entry.body ? (
+                                            <DiaryBodyRenderer body={entry.body} variant="compact" maxBlocks={3} />
+                                        ) : "No details yet."}
+                                    </div>
                                 </div>
                             </Link>
                             <button className={styles.deleteEntryButton} onClick={() => setEntryToDelete(entry)} aria-label={`Remove ${entry.title}`}>

--- a/frontend/src/components/diary/diary-entry-list.tsx
+++ b/frontend/src/components/diary/diary-entry-list.tsx
@@ -58,6 +58,7 @@ export const DiaryEntryList = () => {
                             body={p.body}
                             postedAt={p.createdAt}
                             postedByUserId={p.postedByUserId}
+                            postedByUserName={p.postedByUserName}
                             label={p.label}
                             onDelete={() => {
                                 setEntries(entries.filter(entry => entry.id !== p.id))

--- a/frontend/src/components/diary/diary-entry.module.css
+++ b/frontend/src/components/diary/diary-entry.module.css
@@ -88,6 +88,13 @@
     overflow-wrap: anywhere;
 }
 
+.creatorName {
+    margin-top: 4px;
+    color: #667085;
+    font-size: 14px;
+    font-weight: 700;
+}
+
 @media (max-width: 520px) {
     .header {
         align-items: flex-start;

--- a/frontend/src/components/diary/diary-entry.tsx
+++ b/frontend/src/components/diary/diary-entry.tsx
@@ -21,6 +21,7 @@ export const DiaryEntry = (props: {
     body: string
     postedAt: string
     postedByUserId: string
+    postedByUserName?: string
     label?: string
     onDelete: () => void
 }) => {
@@ -107,6 +108,9 @@ export const DiaryEntry = (props: {
                         <div className={styles.title}>
                             {props.title}
                         </div>
+                        {props.postedByUserName && (
+                            <div className={styles.creatorName}>By {props.postedByUserName}</div>
+                        )}
                     </div>
                     {isAuthor && (
                         <div className={styles.actions}>

--- a/frontend/src/components/diary/lexical-diary.module.css
+++ b/frontend/src/components/diary/lexical-diary.module.css
@@ -238,3 +238,46 @@
     font-size: 20px;
     white-space: pre-wrap;
 }
+
+.readonlyBodyCompact,
+.compactPlainBody {
+    display: -webkit-box;
+    overflow: hidden;
+    color: #3f4a54;
+    font-size: 14px;
+    line-height: 1.4;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+}
+
+.compactPlainBody {
+    white-space: pre-wrap;
+}
+
+.compactParagraph,
+.compactHeading,
+.compactSubheading {
+    margin: 0 0 3px;
+}
+
+.compactHeading,
+.compactSubheading {
+    color: #293241;
+    font-size: 14px;
+    font-weight: 900;
+    line-height: 1.3;
+}
+
+.compactImageFrame {
+    display: inline-block;
+    margin: 4px 6px 0 0;
+    vertical-align: top;
+}
+
+.compactInlineImage {
+    display: block;
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+}

--- a/frontend/src/components/diary/lexical-diary.tsx
+++ b/frontend/src/components/diary/lexical-diary.tsx
@@ -846,14 +846,17 @@ const renderInlineNode = (node: DiaryRichTextInlineNode, key: string) => {
     return <React.Fragment key={key}>{content}</React.Fragment>
 }
 
-const renderBlock = (block: DiaryRichTextBlock, key: string, onImageClick?: (image: { alt?: string, fileId: number }) => void): React.ReactNode => {
+const renderBlock = (block: DiaryRichTextBlock, key: string, options: {
+    isCompact?: boolean
+    onImageClick?: (image: { alt?: string, fileId: number }) => void
+}): React.ReactNode => {
     if (block.type === "image") {
-        const image = <img className={styles.inlineImage} src={diaryImageSource(diaryFileImageUrl(block.fileId))} alt={block.alt ?? ""} />
+        const image = <img className={options.isCompact ? styles.compactInlineImage : styles.inlineImage} src={diaryImageSource(diaryFileImageUrl(block.fileId))} alt={block.alt ?? ""} />
 
         return (
-            <figure className={styles.readonlyImageFrame} key={key}>
-                {onImageClick ? (
-                    <button className={styles.imagePreviewButton} onClick={() => onImageClick({ alt: block.alt, fileId: block.fileId })} type="button">
+            <figure className={options.isCompact ? styles.compactImageFrame : styles.readonlyImageFrame} key={key}>
+                {options.onImageClick ? (
+                    <button className={styles.imagePreviewButton} onClick={() => options.onImageClick?.({ alt: block.alt, fileId: block.fileId })} type="button">
                         {image}
                     </button>
                 ) : image}
@@ -865,32 +868,40 @@ const renderBlock = (block: DiaryRichTextBlock, key: string, onImageClick?: (ima
 
     if (block.type === "paragraph") {
         return (
-            <p className={styles.readonlyParagraph} key={key}>
+            <p className={options.isCompact ? styles.compactParagraph : styles.readonlyParagraph} key={key}>
                 {children}
             </p>
         )
     }
 
     if (block.level === 3) {
-        return <h3 className={styles.readonlySubheading} key={key}>{children}</h3>
+        return <h3 className={options.isCompact ? styles.compactSubheading : styles.readonlySubheading} key={key}>{children}</h3>
     }
 
-    return <h2 className={styles.readonlyHeading} key={key}>{children}</h2>
+    return <h2 className={options.isCompact ? styles.compactHeading : styles.readonlyHeading} key={key}>{children}</h2>
 }
 
 export function DiaryBodyRenderer(props: {
     body: string
+    maxBlocks?: number
     onImageClick?: (image: { alt?: string, fileId: number }) => void
+    variant?: "full" | "compact"
 }) {
+    const isCompact = props.variant === "compact"
+
     if (!isStructuredDiaryBody(props.body)) {
-        return <div className={styles.plainBody}>{props.body}</div>
+        return <div className={isCompact ? styles.compactPlainBody : styles.plainBody}>{props.body}</div>
     }
 
     const document = diaryDocumentFromBody(props.body)
+    const blocks = props.maxBlocks ? document.content.slice(0, props.maxBlocks) : document.content
 
     return (
-        <div className={styles.readonlyBody}>
-            {document.content.map((block, index) => renderBlock(block, String(index), props.onImageClick))}
+        <div className={isCompact ? styles.readonlyBodyCompact : styles.readonlyBody}>
+            {blocks.map((block, index) => renderBlock(block, String(index), {
+                isCompact,
+                onImageClick: props.onImageClick
+            }))}
         </div>
     )
 }

--- a/routes/diary.go
+++ b/routes/diary.go
@@ -11,14 +11,15 @@ import (
 )
 
 type DiaryEntry struct {
-	ID             int     `json:"id"`
-	Title          string  `json:"title"`
-	Body           string  `json:"body"`
-	PostedByUserID string  `json:"postedByUserId"`
-	CreateAt       string  `json:"createdAt"`
-	CanEditDate    bool    `json:"canEditDate"`
-	Label          *string `json:"label"`
-	PictureCount   int     `json:"pictureCount"`
+	ID               int     `json:"id"`
+	Title            string  `json:"title"`
+	Body             string  `json:"body"`
+	PostedByUserID   string  `json:"postedByUserId"`
+	PostedByUserName string  `json:"postedByUserName"`
+	CreateAt         string  `json:"createdAt"`
+	CanEditDate      bool    `json:"canEditDate"`
+	Label            *string `json:"label"`
+	PictureCount     int     `json:"pictureCount"`
 }
 
 type DiaryEntryPicture struct {
@@ -96,6 +97,7 @@ func scanDiaryEntry(scanner interface {
 	var title sql.NullString
 	var body sql.NullString
 	var label sql.NullString
+	var postedByUserName sql.NullString
 	var createdAt time.Time
 	var postedByUserID int
 
@@ -104,6 +106,7 @@ func scanDiaryEntry(scanner interface {
 		&title,
 		&body,
 		&postedByUserID,
+		&postedByUserName,
 		&createdAt,
 		&label,
 		&entry.PictureCount,
@@ -116,6 +119,7 @@ func scanDiaryEntry(scanner interface {
 	entry.Title = title.String
 	entry.Body = body.String
 	entry.PostedByUserID = strconv.Itoa(postedByUserID)
+	entry.PostedByUserName = postedByUserName.String
 	entry.CreateAt = formatDiaryTime(createdAt)
 	entry.CanEditDate = canEditDiaryEntryDate(createdAt, time.Now())
 
@@ -165,7 +169,7 @@ func CreateDiaryEntry(ctx *gin.Context) {
 	row := tx.QueryRowContext(ctx.Request.Context(), `
 		insert into diary_entries (title, body, who_posted_user_id, created_at, label)
 		values ($1, $2, $3, $4, $5)
-		returning id, title, body, who_posted_user_id, created_at, label, 0 as picture_count
+		returning id, title, body, who_posted_user_id, (select name from users where id = who_posted_user_id) as posted_by_user_name, created_at, label, 0 as picture_count
 	`, title, createRequest.Body, userSession.UserID, createdAt, createRequest.Label)
 
 	entry, err := scanDiaryEntry(row)
@@ -202,11 +206,12 @@ func GetDiaryEntry(ctx *gin.Context) {
 	}
 
 	row := db.QueryRowContext(ctx.Request.Context(), `
-		select diary_entries.id, title, body, who_posted_user_id, diary_entries.created_at, label, count(diary_entry_pictures.id) as picture_count
+		select diary_entries.id, title, body, who_posted_user_id, users.name as posted_by_user_name, diary_entries.created_at, label, count(diary_entry_pictures.id) as picture_count
 		from diary_entries
+		left join users on users.id = diary_entries.who_posted_user_id
 		left join diary_entry_pictures on diary_entry_pictures.diary_entry_id = diary_entries.id
 		where diary_entries.id = $1
-		group by diary_entries.id
+		group by diary_entries.id, users.name
 	`, entryId)
 
 	diaryEntry, err := scanDiaryEntry(row)
@@ -749,10 +754,11 @@ func GetDiaryEntries(ctx *gin.Context) {
 	offset, limit := GetOffsetAndLimit(ctx, 0, 30)
 
 	rows, err := db.QueryContext(ctx.Request.Context(), `
-		select diary_entries.id, title, body, who_posted_user_id, diary_entries.created_at, label, count(diary_entry_pictures.id) as picture_count
+		select diary_entries.id, title, body, who_posted_user_id, users.name as posted_by_user_name, diary_entries.created_at, label, count(diary_entry_pictures.id) as picture_count
 		from diary_entries
+		left join users on users.id = diary_entries.who_posted_user_id
 		left join diary_entry_pictures on diary_entry_pictures.diary_entry_id = diary_entries.id
-		group by diary_entries.id
+		group by diary_entries.id, users.name
 		order by diary_entries.created_at desc
 		offset $1 limit $2
 	`, offset, limit)


### PR DESCRIPTION
## Summary
- show diary creator names in entry cards by returning `postedByUserName` from diary APIs
- reuse the rich diary body renderer for compact calendar/day-view previews
- expand label color palette and assign colors from the visible label list to avoid duplicates until the palette is exhausted

## Verification
- `npm run typecheck`
- `npm test`
- `npm run build`
