### PR TITLE
Fallback rich diary images to picture routes

### DIFF
--- a/frontend/__tests__/diary-rich-image-fallback.test.tsx
+++ b/frontend/__tests__/diary-rich-image-fallback.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { beforeEach, expect, it, vi } from "vitest"
+import { DiaryEntry } from "../src/components/diary/diary-entry"
+import { DIARY_RICH_TEXT_DOCUMENT_VERSION } from "../src/components/diary/rich-text-document"
+import { setSession } from "../src/logic/session-manager"
+
+vi.mock("../src/api-methods", () => ({
+    deleteJson: vi.fn(async () => ({})),
+    getJson: vi.fn(async (path: string) => {
+        if (path.includes("/pictures")) {
+            return {
+                payload: [{
+                    id: 29,
+                    fileId: 123,
+                    fileName: "IMG_4719.jpg",
+                    url: "/api/files/123"
+                }]
+            }
+        }
+
+        if (path.includes("/comments/count")) {
+            return { payload: { count: 0 } }
+        }
+
+        if (path.includes("/comments")) {
+            return { payload: [] }
+        }
+
+        return { payload: null }
+    }),
+    postJson: vi.fn(async () => ({}))
+}))
+
+beforeEach(() => {
+    setSession({ username: "teemu", userId: "19" })
+})
+
+it("falls back to attached diary picture route when a rich body image points at a missing file id", async () => {
+    const body = JSON.stringify({
+        version: DIARY_RICH_TEXT_DOCUMENT_VERSION,
+        content: [{
+            type: "image",
+            fileId: 999,
+            alt: "IMG_4719.jpg"
+        }]
+    })
+
+    render(
+        <MemoryRouter>
+            <DiaryEntry
+                id={77}
+                title="Bicycle day"
+                body={body}
+                postedAt="2026-05-22T12:00:00Z"
+                postedByUserId="19"
+                postedByUserName="teemu"
+                label="Bicycle day"
+                onDelete={() => undefined}
+            />
+        </MemoryRouter>
+    )
+
+    const image = await screen.findByAltText("IMG_4719.jpg") as HTMLImageElement
+    expect(image.getAttribute("src")).toBe("/api/files/999?size=medium")
+
+    await waitFor(() => {
+        expect(screen.getByText("By teemu")).toBeTruthy()
+    })
+
+    fireEvent.error(image)
+
+    await waitFor(() => {
+        expect(image.getAttribute("src")).toBe("/api/diary/entry/77/picture/29?size=medium")
+    })
+})

--- a/frontend/src/components/diary/diary-entry.tsx
+++ b/frontend/src/components/diary/diary-entry.tsx
@@ -126,6 +126,8 @@ export const DiaryEntry = (props: {
             </div>
             <DiaryBodyRenderer
                 body={props.body}
+                imageFallbacks={pictures}
+                legacyDiaryEntryId={props.id}
                 onImageClick={image => setPreviewPicture({
                     id: image.fileId,
                     fileId: image.fileId,

--- a/frontend/src/components/diary/lexical-diary.tsx
+++ b/frontend/src/components/diary/lexical-diary.tsx
@@ -24,7 +24,7 @@ import {
     Spread
 } from "lexical"
 import { postFormData } from "../../api-methods"
-import { diaryFileImageUrl, diaryImageSource } from "./diary-image-source"
+import { DiaryImageSize, diaryFileImageUrl, diaryImageSource, diaryImageVariantUrl } from "./diary-image-source"
 import {
     DIARY_RICH_TEXT_DOCUMENT_VERSION,
     DiaryRichTextBlock,
@@ -846,12 +846,62 @@ const renderInlineNode = (node: DiaryRichTextInlineNode, key: string) => {
     return <React.Fragment key={key}>{content}</React.Fragment>
 }
 
+const diaryEntryPictureImageUrl = (entryId: number, pictureId: number, size: DiaryImageSize) => {
+    return diaryImageVariantUrl(`/api/diary/entry/${entryId}/picture/${pictureId}`, size)
+}
+
+function ReadonlyDiaryImage(props: {
+    alt: string
+    className: string
+    fallbackUrl?: string
+    src: string
+}) {
+    const [src, setSrc] = useState(props.src)
+    const [didFallback, setDidFallback] = useState(false)
+
+    return (
+        <img
+            className={props.className}
+            src={src}
+            alt={props.alt}
+            onError={() => {
+                if (!props.fallbackUrl || didFallback) {
+                    return
+                }
+
+                setDidFallback(true)
+                setSrc(props.fallbackUrl)
+            }}
+        />
+    )
+}
+
+export type DiaryImageFallback = {
+    fileId?: number
+    fileName?: string
+    id: number
+}
+
+const findImageFallback = (block: Extract<DiaryRichTextBlock, { type: "image" }>, fallbacks?: DiaryImageFallback[]) => {
+    return fallbacks?.find(fallback => fallback.fileId === block.fileId)
+        ?? fallbacks?.find(fallback => fallback.fileName === block.alt)
+}
+
 const renderBlock = (block: DiaryRichTextBlock, key: string, options: {
+    imageFallbacks?: DiaryImageFallback[]
     isCompact?: boolean
+    legacyDiaryEntryId?: number
     onImageClick?: (image: { alt?: string, fileId: number }) => void
 }): React.ReactNode => {
     if (block.type === "image") {
-        const image = <img className={options.isCompact ? styles.compactInlineImage : styles.inlineImage} src={diaryImageSource(diaryFileImageUrl(block.fileId))} alt={block.alt ?? ""} />
+        const size = options.isCompact ? "thumb" : "medium"
+        const imageUrl = diaryImageSource(diaryFileImageUrl(block.fileId, size))
+        const fallback = findImageFallback(block, options.imageFallbacks)
+        const fallbackPictureId = fallback?.id ?? block.fileId
+        const fallbackUrl = options.legacyDiaryEntryId
+            ? diaryImageSource(diaryEntryPictureImageUrl(options.legacyDiaryEntryId, fallbackPictureId, size))
+            : undefined
+        const image = <ReadonlyDiaryImage className={options.isCompact ? styles.compactInlineImage : styles.inlineImage} src={imageUrl} fallbackUrl={fallbackUrl} alt={block.alt ?? ""} />
 
         return (
             <figure className={options.isCompact ? styles.compactImageFrame : styles.readonlyImageFrame} key={key}>
@@ -883,6 +933,8 @@ const renderBlock = (block: DiaryRichTextBlock, key: string, options: {
 
 export function DiaryBodyRenderer(props: {
     body: string
+    imageFallbacks?: DiaryImageFallback[]
+    legacyDiaryEntryId?: number
     maxBlocks?: number
     onImageClick?: (image: { alt?: string, fileId: number }) => void
     variant?: "full" | "compact"
@@ -899,7 +951,9 @@ export function DiaryBodyRenderer(props: {
     return (
         <div className={isCompact ? styles.readonlyBodyCompact : styles.readonlyBody}>
             {blocks.map((block, index) => renderBlock(block, String(index), {
+                imageFallbacks: props.imageFallbacks,
                 isCompact,
+                legacyDiaryEntryId: props.legacyDiaryEntryId,
                 onImageClick: props.onImageClick
             }))}
         </div>


### PR DESCRIPTION
## Summary
- add an image-level fallback for rich diary body images
- if `/api/files/:id` fails, retry via the legacy diary picture route for that entry
- keeps old rich diary entries with picture IDs rendering in the entry view

## Verification
- `npm run typecheck`
- `npm run build`
- `go test ./routes`

Note: `npm test` currently fails on the existing diary image source expectation on this branch/master, unrelated to this fallback.
